### PR TITLE
Change platform minimum macOS version to 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "AssetGen",
   platforms: [
-    .macOS(.v10_15),
+    .macOS(.v12),
   ],
   targets: [
     .executableTarget(


### PR DESCRIPTION
Since the method below is available only to macOS 12 and higher, we have to constraint the package to conform to the version.

> func data(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse)