### PR TITLE
Fix/Language code derivation for hyphenated locales like `zh-Hant`

### DIFF
--- a/Sources/LinguaLib/Domain/Entities/LocalizationSheet.swift
+++ b/Sources/LinguaLib/Domain/Entities/LocalizationSheet.swift
@@ -11,7 +11,9 @@ public struct LocalizationSheet: Equatable {
 }
 
 public extension LocalizationSheet {
+  /// Returns the locale prefix (e.g. `zh-Hant`, `pt-BR`, `en`) by trimming legacy `_<region>_<descriptor>` suffixes used in sheet headers.
   var languageCode: String {
-    String(language.prefix(2))
+    guard let separatorIndex = language.firstIndex(of: "_") else { return language }
+    return String(language[..<separatorIndex])
   }
 }

--- a/Tests/LinguaTests/Domain/Entities/LocalizationSheetTests.swift
+++ b/Tests/LinguaTests/Domain/Entities/LocalizationSheetTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import LinguaLib
+
+final class LocalizationSheetTests: XCTestCase {
+  func test_languageCode_whenSheetNameUsesLegacyLanguageRegionFormat_returnsLanguageCode() {
+    let sheet = LocalizationSheet(language: "en_US_English", entries: [])
+    
+    XCTAssertEqual(sheet.languageCode, "en")
+  }
+  
+  func test_languageCode_whenSheetNameUsesHyphenatedScriptFormat_returnsLocalePrefix() {
+    let sheet = LocalizationSheet(language: "zh-Hans_CN_Simplified", entries: [])
+    
+    XCTAssertEqual(sheet.languageCode, "zh-Hans")
+  }
+  
+  func test_languageCode_whenSheetNameUsesHyphenatedRegionFormat_returnsLocalePrefix() {
+    let sheet = LocalizationSheet(language: "fr-CA_French_Canadian", entries: [])
+    
+    XCTAssertEqual(sheet.languageCode, "fr-CA")
+  }
+}


### PR DESCRIPTION
## Issue
Sheet headers in Lingua use a `<locale>_<region>_<descriptor>` shape (for example `en_US_English`, `zh-Hans_CN_Simplified`, `fr-CA_French_Canadian`). The previous implementation took `language.prefix(2)`, which truncated locales such as `zh-Hant` and `pt-BR` to just `zh` / `pt`, producing wrong `.lproj` folder names and breaking localization lookup for Traditional Chinese, Simplified Chinese, Brazilian Portuguese, and similar variants.

## Summary
- Trim everything from the first underscore onward instead of taking a fixed 2-character prefix, so the locale prefix (including its script/region subtag) is preserved.
- Document the expected sheet-header shape on `languageCode` so the contract is obvious at the call site.
- Add `LocalizationSheetTests` covering the legacy `en_US_*`, hyphenated-script `zh-Hans_*`, and hyphenated-region `fr-CA_*` formats.