### PR TITLE
Feature/Speed up agentic localization loop

### DIFF
--- a/Sources/Lingua/Application/CommandLineParser/CommandLineParser.swift
+++ b/Sources/Lingua/Application/CommandLineParser/CommandLineParser.swift
@@ -6,6 +6,24 @@ protocol CommandLineParsable {
 }
 
 final class CommandLineParser: CommandLineParsable {
+  /// Flag names that may appear more than once on the command line and are collected into
+  /// `multiValueFlags` (preserving order) rather than overwriting each other in `flags`.
+  static let multiValueFlagNames: Set<String> = ["value", "query"]
+
+  /// Flag names that are *always* boolean — they never consume the following token as a
+  /// value, even if that token doesn't start with `--`. Without this whitelist the parser
+  /// would silently swallow stray positional args (e.g. `--new-section Settings` was
+  /// reading `Settings` as the value of `--new-section`, leaving the boolean unset and
+  /// causing the use case to reject the brand-new section).
+  static let booleanFlagNames: Set<String> = [
+    "new-section",
+    "dry-run",
+    "global",
+    "force",
+    "help",
+    "h"
+  ]
+
   func parse(arguments: [String]) throws -> CommandLineArguments {
     if arguments.count <= 1 {
       // Bare invocation: show help instead of "not enough arguments".
@@ -49,10 +67,23 @@ final class CommandLineParser: CommandLineParsable {
 }
 
 private extension CommandLineParser {
+  static func isHelpToken(_ token: String) -> Bool {
+    let lower = token.lowercased()
+    return lower == "--help" || lower == "-h" || lower == "help"
+  }
+
   func parseAgentCommand(_ command: Command, arguments: [String]) throws -> CommandLineArguments {
     // Layout: lingua <command> <config.json> [positional...] [--flag value] [--bool]
     try validateArgumentCount(arguments, count: 2)
-    let configPath = arguments[2]
+    let configPathOrFlag = arguments[2]
+
+    // Per-subcommand --help: `lingua add --help` (and -h / help) prints help for that
+    // subcommand instead of demanding a config path. Mirrors every other CLI's behavior.
+    if Self.isHelpToken(configPathOrFlag) {
+      return CommandLineArguments(command: command, booleanFlags: ["help"])
+    }
+
+    let configPath = configPathOrFlag
     try validateConfigFilePath(configPath)
 
     var positional: [String] = []
@@ -66,9 +97,17 @@ private extension CommandLineParser {
       let token = arguments[i]
       if token.hasPrefix("--") {
         let name = String(token.dropFirst(2))
+        // Known booleans never consume the next token as their value, even if the next
+        // token doesn't start with `--`. Anything trailing such a flag falls through to
+        // the positional path on the next iteration.
+        if Self.booleanFlagNames.contains(name) {
+          booleanFlags.insert(name)
+          i += 1
+          continue
+        }
         if i + 1 < arguments.count, !arguments[i + 1].hasPrefix("--") {
           let value = arguments[i + 1]
-          if name == "value" {
+          if Self.multiValueFlagNames.contains(name) {
             multi[name, default: []].append(value)
           } else if name == "platform" {
             platform = LocalizationPlatform(rawValue: value.lowercased())
@@ -105,6 +144,10 @@ private extension CommandLineParser {
 
     // Layout: lingua ai <install|uninstall|status> [--target claude|cursor|agents|both] [--global] [--force]
     try validateArgumentCount(arguments, count: 2)
+    // `lingua ai --help` / `lingua ai -h` / `lingua ai help` → print the ai subcommand help.
+    if Self.isHelpToken(arguments[2]) {
+      return CommandLineArguments(command: .ai, booleanFlags: ["help"])
+    }
     guard let sub = Command(rawValue: arguments[2].lowercased()),
           [.install, .uninstall, .status].contains(sub) else {
       throw CommandLineParsingError.invalidUsage(

--- a/Sources/Lingua/Application/Processor/AgentCommandDispatcher.swift
+++ b/Sources/Lingua/Application/Processor/AgentCommandDispatcher.swift
@@ -10,6 +10,13 @@ struct AgentCommandDispatcher {
   let output: AgentJSONOutput
 
   func dispatch(_ args: CommandLineArguments) async throws {
+    // Per-subcommand --help. Accepts the flag whether it appears before or after the
+    // config path so `lingua add --help` and `lingua add ./config.json --help` both work.
+    if args.booleanFlags.contains("help") || args.booleanFlags.contains("h") {
+      print(HelpText.help(for: args.command))
+      return
+    }
+
     do {
       switch args.command {
       case .sections:
@@ -24,24 +31,56 @@ struct AgentCommandDispatcher {
 
       case .find:
         let config = try await loadConfig(args)
-        guard let query = args.positional.first else {
-          throw AgentError(code: "missing_argument", message: "find requires a query argument: lingua find <config> <query>")
+        let queries = args.positional + (args.multiValueFlags["query"] ?? [])
+        guard !queries.isEmpty else {
+          throw AgentError(code: "missing_argument", message: "find requires at least one query argument: lingua find <config> <query> [<query> ...]")
         }
         let limit = Int(args.flags["limit"] ?? "10") ?? 10
-        let result = try await agentFactory.makeFindTranslation(config: config).find(query: query, limit: limit)
-        try output.emitSuccess(result)
+        let finder = agentFactory.makeFindTranslation(config: config)
+        // Single-query keeps the original flat `{canonicalSheet, query, matches}` envelope so
+        // existing callers don't break. Multi-query returns the new `{canonicalSheet, results}`
+        // envelope and reuses a single sheet load for all queries.
+        if queries.count == 1 {
+          let result = try await finder.find(query: queries[0], limit: limit)
+          try output.emitSuccess(result)
+        } else {
+          let result = try await finder.find(queries: queries, limit: limit)
+          try output.emitSuccess(result)
+        }
 
       case .add:
         let config = try await loadConfig(args)
-        let translation = try buildNewTranslation(args)
-        let result = try await agentFactory.makeAddTranslation(config: config).add(translation)
-        try output.emitSuccess(result)
+        let useCase = try agentFactory.makeAddTranslation(config: config)
+        if let batchPath = args.flags["batch"] {
+          let batch = try BatchFileLoader.loadAddBatch(
+            path: batchPath,
+            allowNewSections: args.booleanFlags.contains("new-section"),
+            dryRun: args.booleanFlags.contains("dry-run")
+          )
+          let result = try await useCase.addBatch(batch)
+          try await maybeRunSync(args: args, config: config)
+          try output.emitSuccess(result)
+        } else {
+          let translation = try buildNewTranslation(args)
+          let result = try await useCase.add(translation)
+          try await maybeRunSync(args: args, config: config)
+          try output.emitSuccess(result)
+        }
 
       case .update:
         let config = try await loadConfig(args)
-        let update = try buildTranslationUpdate(args)
-        let result = try await agentFactory.makeUpdateTranslation(config: config).update(update)
-        try output.emitSuccess(result)
+        let useCase = try agentFactory.makeUpdateTranslation(config: config)
+        if let batchPath = args.flags["batch"] {
+          let updates = try BatchFileLoader.loadUpdateBatch(path: batchPath)
+          let result = try await useCase.updateBatch(updates)
+          try await maybeRunSync(args: args, config: config)
+          try output.emitSuccess(result)
+        } else {
+          let update = try buildTranslationUpdate(args)
+          let result = try await useCase.update(update)
+          try await maybeRunSync(args: args, config: config)
+          try output.emitSuccess(result)
+        }
 
       case .delete:
         let config = try await loadConfig(args)
@@ -168,6 +207,31 @@ struct AgentCommandDispatcher {
       out.append(ValueAssignment(language: language, form: form, text: text))
     }
     return out
+  }
+
+  /// If the caller passed `--sync ios|android|ios,android`, regenerate the corresponding
+  /// platform files inline so the agent doesn't need to issue a separate `lingua sync` call.
+  /// Silently a no-op when the flag is absent — keeps the original two-step flow available.
+  private func maybeRunSync(args: CommandLineArguments, config: Config.Localization) async throws {
+    guard let raw = args.flags["sync"] else { return }
+    let tokens = raw.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+    var platforms: [LocalizationPlatform] = []
+    for token in tokens {
+      guard let platform = LocalizationPlatform(rawValue: token) else {
+        throw AgentError(
+          code: "invalid_sync_value",
+          message: "--sync values must be one or more of: ios, android (got '\(token)')"
+        )
+      }
+      if !platforms.contains(platform) { platforms.append(platform) }
+    }
+    if platforms.isEmpty {
+      throw AgentError(code: "invalid_sync_value", message: "--sync requires at least one platform.")
+    }
+    let module = localizationModuleFactory(config)
+    for platform in platforms {
+      try await module.localize(for: platform)
+    }
   }
 
   private func handleAICommand(_ args: CommandLineArguments) throws {

--- a/Sources/Lingua/Application/Processor/AgentCommandDispatcher.swift
+++ b/Sources/Lingua/Application/Processor/AgentCommandDispatcher.swift
@@ -125,9 +125,9 @@ struct AgentCommandDispatcher {
     }
   }
 
-  // MARK: - Helpers
+  // MARK: - Helpers (internal for test access)
 
-  private func loadConfig(_ args: CommandLineArguments) async throws -> Config.Localization {
+  func loadConfig(_ args: CommandLineArguments) async throws -> Config.Localization {
     guard let path = args.configFilePath else {
       throw AgentError(code: "missing_config", message: "Missing config file path")
     }
@@ -138,7 +138,7 @@ struct AgentCommandDispatcher {
     return localization
   }
 
-  private func buildNewTranslation(_ args: CommandLineArguments) throws -> NewTranslation {
+  func buildNewTranslation(_ args: CommandLineArguments) throws -> NewTranslation {
     guard let section = args.flags["section"] else {
       throw AgentError(code: "missing_argument", message: "--section is required")
     }
@@ -158,7 +158,7 @@ struct AgentCommandDispatcher {
     )
   }
 
-  private func buildTranslationUpdate(_ args: CommandLineArguments) throws -> TranslationUpdate {
+  func buildTranslationUpdate(_ args: CommandLineArguments) throws -> TranslationUpdate {
     guard let section = args.flags["section"] else {
       throw AgentError(code: "missing_argument", message: "--section is required")
     }
@@ -179,7 +179,7 @@ struct AgentCommandDispatcher {
   ///
   /// `form == nil` means "use the sheet's detected default plural form" — for most templates
   /// that's `one`, but the use case decides at execution time by inspecting the canonical sheet.
-  private func parseValueFlags(_ raw: [String]) throws -> [ValueAssignment] {
+  func parseValueFlags(_ raw: [String]) throws -> [ValueAssignment] {
     var out: [ValueAssignment] = []
     for entry in raw {
       guard let eq = entry.firstIndex(of: "=") else {
@@ -212,7 +212,7 @@ struct AgentCommandDispatcher {
   /// If the caller passed `--sync ios|android|ios,android`, regenerate the corresponding
   /// platform files inline so the agent doesn't need to issue a separate `lingua sync` call.
   /// Silently a no-op when the flag is absent — keeps the original two-step flow available.
-  private func maybeRunSync(args: CommandLineArguments, config: Config.Localization) async throws {
+  func maybeRunSync(args: CommandLineArguments, config: Config.Localization) async throws {
     guard let raw = args.flags["sync"] else { return }
     let tokens = raw.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
     var platforms: [LocalizationPlatform] = []

--- a/Sources/Lingua/Application/Processor/BatchFileLoader.swift
+++ b/Sources/Lingua/Application/Processor/BatchFileLoader.swift
@@ -1,0 +1,111 @@
+import Foundation
+import LinguaLib
+
+/// Parses the JSON file passed to `lingua add --batch <file>` / `lingua update --batch <file>`.
+///
+/// File shape (a bare array — the agent can produce this without thinking about wrappers):
+///
+/// ```json
+/// [
+///   {
+///     "section": "Settings",
+///     "key": "title",
+///     "values": {"en": "Settings", "de": "Einstellungen"}
+///   },
+///   {
+///     "section": "Cart",
+///     "key": "item_count",
+///     "values": {
+///       "en": {"one": "1 item", "other": "%d items"},
+///       "de": {"one": "1 Artikel", "other": "%d Artikel"}
+///     }
+///   }
+/// ]
+/// ```
+///
+/// Each `values` entry is either a plain string (non-plural — the use case picks the right
+/// column based on the sheet's detected default form) or a `{form: text}` object for plurals.
+enum BatchFileLoader {
+  static func loadAddBatch(path: String, allowNewSections: Bool, dryRun: Bool) throws -> AddTranslationBatch {
+    let entries = try loadEntries(path: path)
+    let items = entries.map { entry in
+      NewTranslationBatchItem(
+        section: entry.section,
+        key: entry.key,
+        assignments: entry.toAssignments()
+      )
+    }
+    return AddTranslationBatch(items: items, allowNewSections: allowNewSections, dryRun: dryRun)
+  }
+
+  static func loadUpdateBatch(path: String) throws -> [TranslationUpdate] {
+    let entries = try loadEntries(path: path)
+    return entries.map { entry in
+      TranslationUpdate(section: entry.section, key: entry.key, assignments: entry.toAssignments())
+    }
+  }
+
+  private static func loadEntries(path: String) throws -> [Entry] {
+    let url = URL(fileURLWithPath: path)
+    let data: Data
+    do {
+      data = try Data(contentsOf: url)
+    } catch {
+      throw AgentError(
+        code: "batch_file_unreadable",
+        message: "Could not read batch file at '\(path)': \(error.localizedDescription)"
+      )
+    }
+    do {
+      return try JSONDecoder().decode([Entry].self, from: data)
+    } catch {
+      throw AgentError(
+        code: "batch_file_invalid",
+        message: "Could not parse batch file: \(error.localizedDescription)"
+      )
+    }
+  }
+}
+
+private struct Entry: Decodable {
+  let section: String
+  let key: String
+  let values: [String: ValuePayload]
+
+  func toAssignments() -> [ValueAssignment] {
+    values.flatMap { language, payload -> [ValueAssignment] in
+      switch payload {
+      case .plain(let text):
+        return [ValueAssignment(language: language, form: nil, text: text)]
+      case .plural(let forms):
+        return forms.map { form, text in
+          ValueAssignment(language: language, form: form, text: text)
+        }
+      }
+    }
+  }
+}
+
+private enum ValuePayload: Decodable {
+  case plain(String)
+  case plural([String: String])
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let text = try? container.decode(String.self) {
+      self = .plain(text)
+      return
+    }
+    if let dict = try? container.decode([String: String].self) {
+      self = .plural(dict)
+      return
+    }
+    throw DecodingError.typeMismatch(
+      ValuePayload.self,
+      DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected either a string or a {form: text} object."
+      )
+    )
+  }
+}

--- a/Sources/Lingua/Application/Processor/HelpText.swift
+++ b/Sources/Lingua/Application/Processor/HelpText.swift
@@ -1,6 +1,166 @@
 import Foundation
+import LinguaLib
 
 enum HelpText {
+  /// Resolves per-subcommand help text. Returns the top-level `usage` for unknown / help
+  /// commands so `lingua --help` keeps working unchanged.
+  static func help(for command: Command?) -> String {
+    switch command {
+    case .add: return addHelp
+    case .update: return updateHelp
+    case .find: return findHelp
+    case .sections: return sectionsHelp
+    case .list: return listHelp
+    case .delete: return deleteHelp
+    case .sync: return syncHelp
+    case .doctor: return doctorHelp
+    case .ai: return aiHelp
+    default: return usage
+    }
+  }
+
+  static let addHelp = """
+  USAGE
+    lingua add <config.json> --section <s> --key <k> --value <lang>[:form]=<text> [--value ...]
+                             [--new-section] [--dry-run] [--sync ios|android|ios,android]
+    lingua add <config.json> --batch <file.json>
+                             [--new-section] [--dry-run] [--sync ios|android|ios,android]
+
+  Insert one or more rows into the canonical Google Sheet, section-aware. Prefer --batch
+  for ≥ 2 keys — one HTTP round trip instead of N.
+
+  FLAGS
+    --section <s>         Target section (must exist unless --new-section is also passed).
+    --key <k>             Snake_case key for the new row.
+    --value <l>[:f]=<t>   Per-language value. Form is one of zero/one/two/few/many/other.
+                          Omit `:form` for non-plural strings (auto-picks the default column).
+    --batch <file>        JSON array of {section, key, values} entries (see SCHEMA below).
+    --new-section         Allow creating a section that doesn't exist yet.
+    --dry-run             Plan the write without sending it.
+    --sync <list>         After writing, regenerate platform files. Comma-separated list of
+                          `ios`, `android`. Saves a separate `lingua sync` invocation.
+
+  --batch JSON SCHEMA
+    [
+      {"section": "Settings", "key": "title",
+       "values": {"en": "Settings", "de": "Einstellungen"}},
+      {"section": "Cart", "key": "item_count",
+       "values": {"en": {"one": "1 item",    "other": "%d items"},
+                  "de": {"one": "1 Artikel", "other": "%d Artikel"}}}
+    ]
+
+  EXAMPLES
+    lingua add ./config.json --section onboarding --key cta_start \\
+      --value en="Get started" --value de="Loslegen" --sync ios
+
+    lingua add ./config.json --batch /tmp/batch.json --new-section --sync ios,android
+  """
+
+  static let updateHelp = """
+  USAGE
+    lingua update <config.json> --section <s> --key <k> --value <lang>[:form]=<text> [--value ...]
+                                [--sync ios|android|ios,android]
+    lingua update <config.json> --batch <file.json>
+                                [--sync ios|android|ios,android]
+
+  Update one or more existing rows in place. Only the cells you supply are touched —
+  unsupplied languages keep their current values. Same JSON schema as `lingua add --batch`.
+
+  FLAGS
+    --section <s>         Section containing the existing row.
+    --key <k>             Key of the existing row.
+    --value <l>[:f]=<t>   Per-language replacement value. Form override is optional —
+                          by default Lingua targets whichever plural column the row uses.
+    --batch <file>        JSON array of {section, key, values} entries.
+    --sync <list>         Regenerate platform files after the update.
+
+  EXAMPLES
+    lingua update ./config.json --section onboarding --key cta_start \\
+      --value en="Begin" --value de="Anfangen" --sync ios
+
+    lingua update ./config.json --batch /tmp/edits.json --sync ios
+  """
+
+  static let findHelp = """
+  USAGE
+    lingua find <config.json> <query> [<query> ...] [--limit <N>]
+
+  Substring-search the canonical sheet. Pass multiple queries to share a single sheet
+  load — Lingua runs every query against the same snapshot.
+
+  Single-query response shape:   {canonicalSheet, query, matches}
+  Multi-query response shape:    {canonicalSheet, results: [{query, matches}, ...]}
+
+  FLAGS
+    --limit <N>           Maximum matches per query (default 10).
+
+  EXAMPLES
+    lingua find ./config.json "save changes"
+    lingua find ./config.json "Settings" "Account" "Display name"
+  """
+
+  static let sectionsHelp = """
+  USAGE
+    lingua sections <config.json>
+
+  List every section in the canonical sheet (with row range and sample keys), and report
+  the list of language tabs so the caller knows which languages need values when adding.
+  """
+
+  static let listHelp = """
+  USAGE
+    lingua list <config.json> [--section <name>]
+
+  Dump every (section, key, values) row from the canonical sheet. Multi-language values
+  are included. Pass --section to filter to one section.
+  """
+
+  static let deleteHelp = """
+  USAGE
+    lingua delete <config.json> --section <s> --key <k>
+
+  Delete a row by (section, key) from every language tab where it exists. Permissive —
+  works even on misaligned tabs, so it's the recovery escape hatch for `tabs_out_of_sync`.
+
+  FLAGS
+    --section <s>         Section of the row to delete.
+    --key <k>             Key of the row to delete.
+  """
+
+  static let syncHelp = """
+  USAGE
+    lingua sync <config.json> --platform ios|android
+
+  Regenerate platform localization files from the Google Sheet. Same effect as the
+  legacy `lingua ios` / `lingua android` commands but with a JSON status envelope.
+  """
+
+  static let doctorHelp = """
+  USAGE
+    lingua doctor <config.json>
+
+  Run health checks against your Lingua configuration: API key, service account, sheet
+  reachability, output dir writable, language-tab alignment. Exits non-zero if any
+  check fails so CI can catch broken state early.
+  """
+
+  static let aiHelp = """
+  USAGE
+    lingua ai install   [--target claude|cursor|agents|both] [--global] [--force]
+    lingua ai uninstall [--target claude|cursor|agents|both] [--global]
+    lingua ai status
+
+  Install / uninstall / inspect the bundled Agent Skills that teach Claude Code, Cursor,
+  and other Agent-Skills-compatible runtimes how to drive Lingua. Default target is
+  auto-detected from `.git/.claude/.cursor/.agents` in the resolved project root (or `~`
+  for --global). `both` = claude + cursor only.
+
+  FLAGS
+    --target <t>          One of claude, cursor, agents, both.
+    --global              Install into ~ instead of the project root.
+    --force               Overwrite existing skill files (install only).
+  """
+
   static let usage = """
   Lingua — localization tool for iOS / Android with AI-agent integration.
 
@@ -17,14 +177,24 @@ enum HelpText {
     lingua sections <config.json>          List sections in the canonical sheet
     lingua list     <config.json> [--section <name>]
                                            Dump all translations
-    lingua find     <config.json> <query>  Search keys/sections/values
+    lingua find     <config.json> <query> [<query> ...]
+                                           Search keys/sections/values. Multiple queries share
+                                           a single sheet load.
     lingua add      <config.json> --section <s> --key <k> --value <lang>[:form]=<text> [--value ...]
-                                           [--new-section] [--dry-run]
+                                           [--new-section] [--dry-run] [--sync ios|android|ios,android]
                                            Insert a new row inside the right section.
                                            --value en="Save"          (auto-picks plural column)
                                            --value en:one="1 item" --value en:other="%d items"
+    lingua add      <config.json> --batch <file.json> [--new-section] [--dry-run]
+                                           [--sync ios|android|ios,android]
+                                           Insert many rows in a single round trip. The file
+                                           is a JSON array of {section, key, values}; `values`
+                                           may be {lang: "text"} or {lang: {form: "text"}}.
     lingua update   <config.json> --section <s> --key <k> --value <lang>[:form]=<text> [--value ...]
+                                           [--sync ios|android|ios,android]
                                            Update an existing row's values in place
+    lingua update   <config.json> --batch <file.json> [--sync ios|android|ios,android]
+                                           Batched in-place updates. Same JSON shape as add.
     lingua delete   <config.json> --section <s> --key <k>
                                            Delete a row across all language tabs (recovery tool)
     lingua doctor   <config.json>          Verify config / auth / sheet alignment

--- a/Sources/LinguaLib/Application/AI/LinguaAIBundledSkills.swift
+++ b/Sources/LinguaLib/Application/AI/LinguaAIBundledSkills.swift
@@ -25,10 +25,10 @@ public enum LinguaAIBundledSkills {
   public static let addTranslation = """
   ---
   name: lingua-add-translation
-  description: Add a new localized string to the project's Google Sheet via the Lingua CLI, then regenerate platform localization files. Use this whenever the user asks for a new user-facing string, or whenever you would otherwise hardcode a user-facing string in code.
+  description: Add one or more localized strings to the project's Google Sheet via the Lingua CLI, then regenerate platform localization files. Use this whenever the user asks for a new user-facing string, or whenever you would otherwise hardcode a user-facing string in code.
   ---
 
-  # Adding a new translation with Lingua
+  # Adding new translations with Lingua
 
   Lingua manages localization in a Google Sheet and generates platform files (iOS `.strings` /
   `.stringsdict` / `Lingua.swift`, Android `strings.xml`) from it. Translations are organized
@@ -50,7 +50,8 @@ public enum LinguaAIBundledSkills {
   If a `Lingua.<Section>.<key>` reference doesn't compile after you added a key, the answer is
   **never** to edit `Lingua.swift`. The answer is always one of:
 
-  1. You forgot to run `lingua sync` after `lingua add` → run it now.
+  1. You forgot to run `lingua sync` after `lingua add` → run it now (or use `--sync ios`
+     on the add).
   2. The section name is lowercase but should be capitalized (`login` vs `Login`) → use
      `lingua delete` to remove the bad rows and re-add with the correct casing.
   3. The key contains characters that don't map cleanly to a Swift identifier → re-add with a
@@ -58,28 +59,28 @@ public enum LinguaAIBundledSkills {
 
   ## Inputs you must gather before running
 
-  - The English text of the new string.
-  - The screen / feature it belongs to (used to pick the section).
+  - The English text of every new string (gather them ALL up front, even if there are 20).
+  - The screen / feature they belong to (used to pick the section).
   - The path to the project's `lingua_config.json`.
 
   ## Procedure
 
-  1. **Check for an existing key first.** Duplication is the most common mistake.
+  1. **Check for existing keys first** with a single multi-query find — this avoids three
+     separate sheet fetches when you have several candidates:
      ```bash
-     lingua find ./lingua_config.json "<english text>"
+     lingua find ./lingua_config.json "settings" "account" "display name"
      ```
      If a close match exists, **stop and suggest reusing it** instead of creating a new key.
 
-  2. **List existing sections + languages** so you place the new key in the right group AND
+  2. **List existing sections + languages** so you place the new keys in the right group AND
      know which languages need values.
      ```bash
      lingua sections ./lingua_config.json
      ```
      Read the JSON output. Two things matter:
      - `data.languages` is the list of language tabs in the sheet (e.g. `[{"code":"en",...},{"code":"de",...}]`).
-       **You must provide a `--value` for every language code in this list** (see step 4).
-       Skipping a language leaves the row blank in that tab and risks misaligning future
-       writes.
+       **You must provide a value for every language code in this list.** Skipping a language
+       leaves the row blank in that tab and risks misaligning future writes.
      - `data.sections` is the list of existing sections. Pick the right one using these
        heuristics, in order:
        1. The feature folder of the file the new string will be used in
@@ -89,35 +90,47 @@ public enum LinguaAIBundledSkills {
           *"I'm about to create a new section `X`, is that what you want?"* before passing
           `--new-section`.
 
-  3. **Pick a `snake_case` key** that's specific to the screen/intent, not the literal text.
-     Prefer `empty_state_message` over `no_favorites_yet` — keys should describe purpose, not
-     content.
+  3. **Pick a `snake_case` key** for each string that's specific to the screen/intent, not the
+     literal text. Prefer `empty_state_message` over `no_favorites_yet` — keys should describe
+     purpose, not content.
 
-  4. **Add the row** with a `--value` for **every language** returned by `lingua sections`.
-     If you don't speak a language, translate the English text yourself or ask the user — but
-     never skip a language.
-     ```bash
-     lingua add ./lingua_config.json \
-       --section onboarding \
-       --key cta_start \
-       --value en="Get started" \
-       --value de="Loslegen"
+  4. **Submit ALL strings in one batched call.** This is dramatically faster than chaining
+     individual `lingua add` invocations (each one re-fetches the whole sheet and re-signs the
+     service account JWT). Write the entries to a JSON file and pass it via `--batch`. Always
+     include `--sync ios` (and/or `--sync android`) so the platform files are regenerated in
+     the same invocation.
+
+     **`/tmp/lingua-batch.json`** — bare JSON array, plain strings for non-plural, `{form:
+     text}` objects for plurals:
+     ```json
+     [
+       {"section": "Settings", "key": "title", "values": {"en": "Settings", "de": "Einstellungen"}},
+       {"section": "Settings", "key": "account", "values": {"en": "Account", "de": "Konto"}},
+       {"section": "Settings", "key": "item_count", "values": {
+         "en": {"one": "1 item", "other": "%d items"},
+         "de": {"one": "1 Artikel", "other": "%d Artikel"}
+       }}
+     ]
      ```
 
-     **Plural form column:** by default `lingua add` writes the value into whichever plural
-     column the sheet's existing rows use (auto-detected — usually `one` for non-plural strings,
-     matching the README template). You almost never need to think about this. Only override
-     when adding an actually-plural string:
      ```bash
-     lingua add ./lingua_config.json \
-       --section cart \
-       --key item_count \
-       --value en:one="1 item" --value en:other="%d items" \
-       --value de:one="1 Artikel" --value de:other="%d Artikel"
+     lingua add ./lingua_config.json --batch /tmp/lingua-batch.json --sync ios
+     # Add --new-section if the batch introduces a section that doesn't exist yet.
+     # --new-section is a BOOLEAN switch — it takes NO value. The section name lives in
+     # the JSON. Wrong: `--new-section Settings`. Right: just `--new-section`.
+     # Add --sync android too (or use --sync ios,android) if the project ships for Android.
      ```
-     The syntax is `<lang>:<form>=<text>` where `<form>` is one of `zero`, `one`, `two`, `few`,
-     `many`, `other` (CLDR plural categories). For non-plural strings, omit the `:form` part
-     entirely — Lingua will pick the right column for you.
+
+     Plural forms must be one of `zero`, `one`, `two`, `few`, `many`, `other` (CLDR plural
+     categories). For non-plural strings, use the plain `"<lang>": "<text>"` form — Lingua
+     picks the right column automatically.
+
+     **Only fall back to per-string flags** if you're truly adding exactly one key:
+     ```bash
+     lingua add ./lingua_config.json --section onboarding --key cta_start \\
+       --value en="Get started" --value de="Loslegen" --sync ios
+     ```
+
      Parse the JSON response. Handle errors:
      - `error.code == "duplicate_key"` → stop, surface the existing row, suggest reusing it.
      - `error.code == "unknown_section"` → re-read `error.details.suggestions`, ask the user.
@@ -129,26 +142,19 @@ public enum LinguaAIBundledSkills {
      - `error.code == "missing_service_account"` → tell the user to set
        `serviceAccountKeyPath` in their `lingua_config.json` and run `lingua doctor`.
 
-  5. **Regenerate platform files.**
-     ```bash
-     lingua sync ./lingua_config.json --platform ios
-     ```
-     (Also run with `--platform android` if both are configured.)
-
-  6. **Use the new key in code.** The sheet stores `snake_case`, but the generated code on
+  5. **Use the new keys in code.** The sheet stores `snake_case`, but the generated code on
      each platform transforms it. **Never call the snake_case key from code** — always use
-     the transformed identifier the generator produced. After `lingua sync`, open
-     `Lingua.swift` (iOS) / `strings.xml` (Android) and copy the exact symbol if you're not
-     sure.
+     the transformed identifier the generator produced.
 
-     **iOS — `Lingua.<Section>.<key>`** (transformations applied by `lingua sync`):
-     - Section name → `PascalCase` (`general` → `General`, `empty_states` → `EmptyStates`).
-     - Key → `camelCase` (`app_description` → `appDescription`, `cta_start` → `ctaStart`,
-       `empty_state_message` → `emptyStateMessage`).
-     - Final reference: `Lingua.General.appDescription`, **not** `Lingua.General.app_description`.
-     - Reserved Swift identifiers get backticked automatically (`class` → `` `class` ``).
-     - If `Lingua.<Section>.<key>` does not compile, the cause is almost always that you
-       wrote the raw `snake_case` key instead of the camelCased one. Re-check `Lingua.swift`.
+     **iOS — non-plural keys** become `Lingua.<PascalSection>.<camelKey>`:
+     - Section `general`, key `app_description` → `Lingua.General.appDescription`.
+     - **Not** `Lingua.General.app_description`. Section is PascalCase, key is camelCase.
+
+     **iOS — plural keys** become `Lingua.<PascalSection>.<camelKey>(_:)` — a function that
+     takes the count and returns the localized string:
+     - Section `settings`, key `photo_count` (plural) → `Lingua.Settings.photoCount(photoCount)`.
+     - The count argument is required for plurals; the generated stringsdict resolves it via
+       `%d`. If you see a plain `Lingua.Settings.photoCount` it won't compile — pass the count.
 
      **Android — `R.string.<section>_<key>`** (lowercased, snake_case preserved):
      - Identifier is `(section + "_" + key).lowercased()`.
@@ -156,6 +162,10 @@ public enum LinguaAIBundledSkills {
      - Unlike iOS, Android keeps `snake_case`. Don't camelCase it.
      - When in doubt, grep `strings.xml` for the `<string name="...">` entry and use that
        name verbatim.
+
+     Reserved Swift identifiers get backticked automatically (`class` → `` `class` ``).
+     If a reference doesn't compile, the cause is almost always (a) you wrote `snake_case`
+     instead of `camelCase`, or (b) you forgot the `(_:)` count argument on a plural.
 
   > **Section separators are automatic.** When `lingua add --new-section` creates a new
   > section in a non-empty sheet, it automatically leaves one blank row above the new section
@@ -165,6 +175,11 @@ public enum LinguaAIBundledSkills {
   ## Hard rules
 
   - Always run `lingua find` and `lingua sections` *before* `lingua add`. Never skip them.
+  - **Prefer `--batch` for any non-trivial add** (≥ 2 strings, or when section/plural mix
+    means you'd otherwise chain commands). One batched call replaces N sequential ones, and
+    each sequential `lingua add` costs ~3–5 seconds of fixed overhead.
+  - Always pair the add with `--sync ios` (or `--sync ios,android`) so the platform files
+    regenerate in the same invocation — saves another full sheet round-trip.
   - Never pass `--new-section` without explicit user confirmation.
   - **Never create or edit `Lingua.swift`, `Localizable.strings`, `Localizable.stringsdict`, or
     Android `strings.xml`.** They're regenerated from the Google Sheet by `lingua sync`. If they look
@@ -178,51 +193,59 @@ public enum LinguaAIBundledSkills {
   public static let updateTranslation = """
   ---
   name: lingua-update-translation
-  description: Update the value of an existing localized string in the project's Google Sheet via the Lingua CLI, then regenerate platform localization files. Use when the user asks to fix wording, change a translation, or rename a localized message.
+  description: Update one or more existing localized strings in the project's Google Sheet via the Lingua CLI, then regenerate platform localization files. Use when the user asks to fix wording, change a translation, or rename a localized message.
   ---
 
-  # Updating an existing translation with Lingua
+  # Updating existing translations with Lingua
 
   ## Procedure
 
-  1. **Find the row.**
+  1. **Find the row(s).** Pass every search term in a single multi-query find so the sheet is
+     only loaded once:
      ```bash
-     lingua find ./lingua_config.json "<text or key>"
+     lingua find ./lingua_config.json "<text or key>" "<another>"
      ```
      If multiple matches, ask the user which `(section, key)` to update.
 
-  2. **Update in place.**
-     ```bash
-     lingua update ./lingua_config.json \
-       --section onboarding \
-       --key cta_start \
-       --value en="Begin" \
-       --value de="Anfangen"
+  2. **Update in place.** For two or more keys, batch them — the per-call sheet fetch /
+     auth cost is the same whether you change one cell or one hundred, so don't pay it twice.
+
+     **`/tmp/lingua-update.json`** — same shape as `lingua add --batch`:
+     ```json
+     [
+       {"section": "Settings", "key": "title", "values": {"en": "Preferences", "de": "Einstellungen"}},
+       {"section": "Cart", "key": "item_count", "values": {
+         "en": {"other": "%d things"}
+       }}
+     ]
      ```
+     ```bash
+     lingua update ./lingua_config.json --batch /tmp/lingua-update.json --sync ios
+     ```
+
+     **Single-key fallback** (only when you have exactly one row to change):
+     ```bash
+     lingua update ./lingua_config.json --section onboarding --key cta_start \\
+       --value en="Begin" --value de="Anfangen" --sync ios
+     ```
+
      `lingua update` only touches the cells you specify. By default it updates whichever plural
-     column the existing row uses (so non-plural strings stay non-plural). To target a specific
-     plural form, use `--value <lang>:<form>=<text>`:
-     ```bash
-     lingua update ./lingua_config.json \
-       --section cart \
-       --key item_count \
-       --value en:other="%d things"
-     ```
+     column the existing row already uses (so non-plural strings stay non-plural). To target a
+     specific plural form, use the `{form: text}` object form in the batch JSON, or
+     `--value <lang>:<form>=<text>` on the CLI.
 
      Errors to handle:
-     - `error.code == "not_found"` → the row doesn't exist; suggest `lingua-add-translation`.
+     - `error.code == "not_found"` (single mode) or a non-empty `data.notFound[]` (batch mode)
+       → the row doesn't exist; suggest `lingua-add-translation`.
      - `error.code == "tabs_out_of_sync"` → run `lingua doctor`.
 
-  3. **Regenerate platform files.**
-     ```bash
-     lingua sync ./lingua_config.json --platform ios
-     ```
-
-  4. **Reference the key from code with the platform-transformed identifier**, never the raw
+  3. **Reference the key from code with the platform-transformed identifier**, never the raw
      `snake_case` key from the sheet:
-     - **iOS**: `Lingua.<PascalSection>.<camelKey>` — section becomes `PascalCase`, key becomes
-       `camelCase`. e.g. sheet `General / app_description` → `Lingua.General.appDescription`.
-       **Not** `Lingua.General.app_description`.
+     - **iOS non-plural**: `Lingua.<PascalSection>.<camelKey>` — section becomes `PascalCase`,
+       key becomes `camelCase`. e.g. sheet `General / app_description` →
+       `Lingua.General.appDescription`. **Not** `Lingua.General.app_description`.
+     - **iOS plural**: `Lingua.<PascalSection>.<camelKey>(_:)` — takes the count argument.
+       e.g. sheet `Settings / photo_count` → `Lingua.Settings.photoCount(photoCount)`.
      - **Android**: `R.string.<section>_<key>` lowercased, snake_case preserved. e.g.
        `R.string.general_app_description`.
      - If unsure, open the regenerated `Lingua.swift` / `strings.xml` and copy the symbol.
@@ -230,7 +253,9 @@ public enum LinguaAIBundledSkills {
   ## Hard rules
 
   - `update` never moves rows. It only changes values in place.
-  - Only languages you pass with `--value` are touched. Others stay as-is.
+  - Only languages you pass values for are touched. Others stay as-is.
+  - **Prefer `--batch` and `--sync` together** for any non-trivial update — same speed
+    rationale as `lingua-add-translation`.
   - **Never create or edit `Lingua.swift`, `Localizable.strings`, `Localizable.stringsdict`, or
     Android `strings.xml`.** They're regenerated from the Google Sheet by `lingua sync`. If a string
     on screen still looks wrong after `lingua update`, run `lingua sync` again — don't reach
@@ -251,7 +276,19 @@ public enum LinguaAIBundledSkills {
   lingua find ./lingua_config.json "save changes"
   ```
 
-  The JSON response contains a ranked list of matches with `section`, `key`, and `englishValue`.
+  When you have **several candidate strings** to look up, pass them as additional positional
+  arguments in one call — Lingua loads the sheet once and runs every search against the same
+  snapshot:
+
+  ```bash
+  lingua find ./lingua_config.json "save changes" "discard" "are you sure"
+  ```
+
+  The single-query call returns `{canonicalSheet, query, matches}`. The multi-query call
+  returns `{canonicalSheet, results}` where each `results[i]` has its own `query` and
+  `matches`.
+
+  Each match contains `section`, `key`, and `englishValue`.
   Use the platform-transformed identifier — never the raw `snake_case` key from the sheet:
 
   - **iOS**: `Lingua.<PascalSection>.<camelKey>` — section is `PascalCase`, key is `camelCase`.

--- a/Sources/LinguaLib/Common/Extensions/String+Extension.swift
+++ b/Sources/LinguaLib/Common/Extensions/String+Extension.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension String {
   static let packageName = "Lingua"
-  static let version = "1.1.0"
+  static let version = "1.1.1"
   static let swiftLocalizedName = "\(String.packageName).swift"
   static let fileHeader = """
   This file was generated with Lingua command line tool. Please do not change it!

--- a/Sources/LinguaLib/Domain/UseCases/Agent/AddTranslationUseCase.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Agent/AddTranslationUseCase.swift
@@ -31,6 +31,48 @@ public struct AddedTranslation: Encodable {
 
 public protocol AddingTranslation {
   func add(_ translation: NewTranslation) async throws -> AddedTranslation
+  func addBatch(_ batch: AddTranslationBatch) async throws -> AddedBatch
+}
+
+public struct NewTranslationBatchItem: Equatable {
+  public let section: String
+  public let key: String
+  public let assignments: [ValueAssignment]
+
+  public init(section: String, key: String, assignments: [ValueAssignment]) {
+    self.section = section
+    self.key = key
+    self.assignments = assignments
+  }
+}
+
+public struct AddTranslationBatch: Equatable {
+  public let items: [NewTranslationBatchItem]
+  public let allowNewSections: Bool
+  public let dryRun: Bool
+
+  public init(items: [NewTranslationBatchItem], allowNewSections: Bool, dryRun: Bool) {
+    self.items = items
+    self.allowNewSections = allowNewSections
+    self.dryRun = dryRun
+  }
+}
+
+public struct AddedBatchEntry: Encodable {
+  public let section: String
+  public let key: String
+  public let rowIndex: Int
+  public let createdNewSection: Bool
+}
+
+public struct AddedBatch: Encodable {
+  public let totalAdded: Int
+  public let createdSections: [String]
+  public let resolvedDefaultForm: String
+  public let languagesWritten: [String]
+  public let languagesSkipped: [String]
+  public let items: [AddedBatchEntry]
+  public let dryRun: Bool
 }
 
 public struct AddTranslationUseCase: AddingTranslation {
@@ -203,6 +245,167 @@ public struct AddTranslationUseCase: AddingTranslation {
       .sorted { $0.distance < $1.distance }
       .prefix(limit)
       .map(\.name)
+  }
+}
+
+// MARK: - Batch
+
+extension AddTranslationUseCase {
+  public func addBatch(_ batch: AddTranslationBatch) async throws -> AddedBatch {
+    let sheets = try await sheetDataLoader.loadSheets()
+    guard let canonical = CanonicalSheetSelector.pick(from: sheets, preferred: preferredSheet) else {
+      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
+    }
+
+    try assertTabsAligned(sheets: sheets, canonical: canonical)
+
+    // Validate plural forms up-front so we can fail fast without doing any work.
+    for item in batch.items {
+      for a in item.assignments {
+        if let form = a.form, PluralColumnLayout.column(forForm: form) == nil {
+          throw AgentError(
+            code: "invalid_plural_form",
+            message: "Unknown plural form '\(form)'. Valid: \(PluralColumnLayout.formsInColumnOrder.joined(separator: ", "))",
+            details: ["form": form]
+          )
+        }
+      }
+    }
+
+    // Reject duplicates against the canonical sheet AND within the batch itself.
+    var seenIdentities = Set(canonical.entries.map { "\($0.section)::\($0.key)" })
+    for item in batch.items {
+      let identity = "\(item.section)::\(item.key)"
+      if seenIdentities.contains(identity) {
+        throw AgentError(
+          code: "duplicate_key",
+          message: "Key '\(item.key)' already exists in section '\(item.section)'.",
+          details: ["section": item.section, "key": item.key]
+        )
+      }
+      seenIdentities.insert(identity)
+    }
+
+    let defaultForm = PluralColumnLayout.detectDefaultForm(in: canonical.entries)
+    let existingSections = Set(canonical.entries.map(\.section))
+
+    // Group items by section, preserving first-seen order so multiple items going to the same
+    // section land as a contiguous block of consecutive rows.
+    var sectionOrder: [String] = []
+    var itemsBySection: [String: [NewTranslationBatchItem]] = [:]
+    for item in batch.items {
+      if itemsBySection[item.section] == nil {
+        sectionOrder.append(item.section)
+      }
+      itemsBySection[item.section, default: []].append(item)
+    }
+
+    struct SectionPlan {
+      let section: String
+      let firstRow: Int
+      let isNew: Bool
+      let items: [NewTranslationBatchItem]
+    }
+
+    var plans: [SectionPlan] = []
+    // Tracks the last row "used" by planning so far. New sections appended at the bottom
+    // advance this cursor by (their item count) — each new section also reserves one blank
+    // separator row above itself, baked into the `+2` offset below.
+    var newSectionCursor = canonical.entries.last?.sheetRow ?? 1
+
+    for section in sectionOrder {
+      guard let sectionItems = itemsBySection[section] else { continue }
+      if existingSections.contains(section) {
+        let lastInSection = canonical.entries.last { $0.section == section }!
+        plans.append(SectionPlan(
+          section: section,
+          firstRow: lastInSection.sheetRow + 1,
+          isNew: false,
+          items: sectionItems
+        ))
+      } else {
+        guard batch.allowNewSections else {
+          let suggestions = Self.closestSections(to: section, in: canonical.entries, limit: 3)
+          throw AgentError(
+            code: "unknown_section",
+            message: "Section '\(section)' does not exist. Pass --new-section to create it. Closest matches: \(suggestions.joined(separator: ", "))",
+            details: ["suggestions": suggestions.joined(separator: ",")]
+          )
+        }
+        let firstRow = newSectionCursor + 2
+        plans.append(SectionPlan(
+          section: section,
+          firstRow: firstRow,
+          isNew: true,
+          items: sectionItems
+        ))
+        newSectionCursor = firstRow + sectionItems.count - 1
+      }
+    }
+
+    // Build the per-tab edits. Each plan produces one edit per language tab so the same row
+    // range receives the right cells in every language sheet — keeping the tabs aligned.
+    var edits: [SheetBatchEdit] = []
+    var addedItems: [AddedBatchEntry] = []
+    var createdSections: [String] = []
+
+    for plan in plans {
+      if plan.isNew {
+        createdSections.append(plan.section)
+      }
+      var nextRow = plan.firstRow
+      for item in plan.items {
+        addedItems.append(AddedBatchEntry(
+          section: item.section,
+          key: item.key,
+          rowIndex: nextRow,
+          createdNewSection: plan.isNew
+        ))
+        nextRow += 1
+      }
+      for sheet in sheets {
+        let rows: [[String]] = plan.items.map { item in
+          let langAssignments = item.assignments.filter { $0.language == sheet.languageCode }
+          return Self.buildRowCells(
+            section: item.section,
+            key: item.key,
+            assignments: langAssignments,
+            defaultForm: defaultForm
+          )
+        }
+        edits.append(SheetBatchEdit(
+          sheetTab: sheet.language,
+          startRow: plan.firstRow,
+          rows: rows,
+          mode: plan.isNew ? .writeOnly : .insertRows
+        ))
+      }
+    }
+
+    let allLangsTouched = Set(batch.items.flatMap { $0.assignments.map(\.language) })
+    var languagesWritten: [String] = []
+    var languagesSkipped: [String] = []
+    for sheet in sheets {
+      if allLangsTouched.contains(sheet.languageCode) {
+        languagesWritten.append(sheet.language)
+      } else {
+        languagesSkipped.append(sheet.language)
+      }
+    }
+
+    if !batch.dryRun {
+      try await writer.applyBatchEdits(edits)
+    }
+
+    return AddedBatch(
+      totalAdded: batch.items.count,
+      createdSections: createdSections,
+      resolvedDefaultForm: defaultForm,
+      languagesWritten: languagesWritten,
+      languagesSkipped: languagesSkipped,
+      items: addedItems,
+      dryRun: batch.dryRun
+    )
   }
 }
 

--- a/Sources/LinguaLib/Domain/UseCases/Agent/CanonicalSheetSelector.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Agent/CanonicalSheetSelector.swift
@@ -12,4 +12,18 @@ enum CanonicalSheetSelector {
     }
     return sheets.first
   }
+
+  /// Picks the canonical tab name when only metadata is available — same preference order as
+  /// `pick(from:preferred:)`, but operates on raw tab titles to avoid fetching every tab's data.
+  static func pickTabName(from tabNames: [String], preferred: String?) -> String? {
+    if let preferred, tabNames.contains(preferred) { return preferred }
+    if let english = tabNames.first(where: { languageCode(forTabName: $0) == "en" }) { return english }
+    return tabNames.first
+  }
+
+  /// Derives the locale prefix from a tab title using the same rule as `LocalizationSheet.languageCode`.
+  static func languageCode(forTabName tabName: String) -> String {
+    guard let separator = tabName.firstIndex(of: "_") else { return tabName }
+    return String(tabName[..<separator])
+  }
 }

--- a/Sources/LinguaLib/Domain/UseCases/Agent/FindTranslationUseCase.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Agent/FindTranslationUseCase.swift
@@ -15,8 +15,14 @@ public struct FindTranslationResult: Encodable {
   public let matches: [FindMatch]
 }
 
+public struct MultiFindTranslationResult: Encodable {
+  public let canonicalSheet: String
+  public let results: [FindTranslationResult]
+}
+
 public protocol FindingTranslations {
   func find(query: String, limit: Int) async throws -> FindTranslationResult
+  func find(queries: [String], limit: Int) async throws -> MultiFindTranslationResult
 }
 
 public struct FindTranslationUseCase: FindingTranslations {
@@ -29,11 +35,17 @@ public struct FindTranslationUseCase: FindingTranslations {
   }
 
   public func find(query: String, limit: Int = 10) async throws -> FindTranslationResult {
-    let sheets = try await sheetDataLoader.loadSheets()
-    guard let canonical = CanonicalSheetSelector.pick(from: sheets, preferred: preferredSheet) else {
-      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
-    }
+    let load = try await sheetDataLoader.loadCanonicalSheet(preferred: preferredSheet)
+    return Self.search(query: query, in: load.canonical, limit: limit)
+  }
 
+  public func find(queries: [String], limit: Int = 10) async throws -> MultiFindTranslationResult {
+    let load = try await sheetDataLoader.loadCanonicalSheet(preferred: preferredSheet)
+    let results = queries.map { Self.search(query: $0, in: load.canonical, limit: limit) }
+    return MultiFindTranslationResult(canonicalSheet: load.canonical.language, results: results)
+  }
+
+  static func search(query: String, in canonical: LocalizationSheet, limit: Int) -> FindTranslationResult {
     let normalizedQuery = query.lowercased()
     var matches: [FindMatch] = []
 
@@ -81,5 +93,15 @@ public struct FindTranslationUseCase: FindingTranslations {
       query: query,
       matches: Array(matches.prefix(limit))
     )
+  }
+}
+
+public extension FindingTranslations {
+  func find(query: String) async throws -> FindTranslationResult {
+    try await find(query: query, limit: 10)
+  }
+
+  func find(queries: [String]) async throws -> MultiFindTranslationResult {
+    try await find(queries: queries, limit: 10)
   }
 }

--- a/Sources/LinguaLib/Domain/UseCases/Agent/ListSectionsUseCase.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Agent/ListSectionsUseCase.swift
@@ -14,14 +14,13 @@ public struct ListSectionsUseCase: ListingSections {
   }
 
   public func listSections() async throws -> ListSectionsResult {
-    let sheets = try await sheetDataLoader.loadSheets()
-    guard let canonical = CanonicalSheetSelector.pick(from: sheets, preferred: preferredSheet) else {
-      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
-    }
+    let load = try await sheetDataLoader.loadCanonicalSheet(preferred: preferredSheet)
     return ListSectionsResult(
-      canonicalSheet: canonical.language,
-      languages: sheets.map { LanguageInfo(code: $0.languageCode, tabName: $0.language) },
-      sections: Self.summarize(entries: canonical.entries)
+      canonicalSheet: load.canonical.language,
+      languages: load.allLanguageTabNames.map {
+        LanguageInfo(code: CanonicalSheetSelector.languageCode(forTabName: $0), tabName: $0)
+      },
+      sections: Self.summarize(entries: load.canonical.entries)
     )
   }
 

--- a/Sources/LinguaLib/Domain/UseCases/Agent/UpdateTranslationUseCase.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Agent/UpdateTranslationUseCase.swift
@@ -29,6 +29,25 @@ public struct UpdatedCell: Encodable {
 
 public protocol UpdatingTranslation {
   func update(_ update: TranslationUpdate) async throws -> UpdatedTranslation
+  func updateBatch(_ updates: [TranslationUpdate]) async throws -> UpdatedBatch
+}
+
+public struct UpdatedBatchEntry: Encodable {
+  public let section: String
+  public let key: String
+  public let rowIndex: Int
+  public let cellsUpdated: [UpdatedCell]
+}
+
+public struct UpdatedBatch: Encodable {
+  public let totalUpdated: Int
+  public let items: [UpdatedBatchEntry]
+  public let notFound: [NotFoundEntry]
+}
+
+public struct NotFoundEntry: Encodable {
+  public let section: String
+  public let key: String
 }
 
 public struct UpdateTranslationUseCase: UpdatingTranslation {
@@ -130,6 +149,97 @@ public struct UpdateTranslationUseCase: UpdatingTranslation {
       resolvedDefaultForm: defaultForm,
       cellsUpdated: cellsUpdated,
       languagesSkipped: languagesSkipped
+    )
+  }
+
+  public func updateBatch(_ updates: [TranslationUpdate]) async throws -> UpdatedBatch {
+    let sheets = try await sheetDataLoader.loadSheets()
+    guard let canonical = CanonicalSheetSelector.pick(from: sheets, preferred: preferredSheet) else {
+      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
+    }
+
+    // One alignment check up front (vs once per item) — every cell write below assumes the
+    // canonical row position matches every other tab's row position.
+    let canonicalKeys = canonical.entries.map { "\($0.section)::\($0.key)" }
+    for sheet in sheets where sheet.language != canonical.language {
+      let theseKeys = sheet.entries.map { "\($0.section)::\($0.key)" }
+      if theseKeys != canonicalKeys {
+        throw AgentError(
+          code: "tabs_out_of_sync",
+          message: "Language tab '\(sheet.language)' is not aligned with canonical tab '\(canonical.language)'.",
+          details: ["misalignedTab": sheet.language]
+        )
+      }
+    }
+
+    // Plural-form validation up front.
+    for update in updates {
+      for a in update.assignments {
+        if let form = a.form, PluralColumnLayout.column(forForm: form) == nil {
+          throw AgentError(
+            code: "invalid_plural_form",
+            message: "Unknown plural form '\(form)'. Valid: \(PluralColumnLayout.formsInColumnOrder.joined(separator: ", "))",
+            details: ["form": form]
+          )
+        }
+      }
+    }
+
+    var edits: [SheetBatchEdit] = []
+    var entries: [UpdatedBatchEntry] = []
+    var notFound: [NotFoundEntry] = []
+
+    for update in updates {
+      guard let offset = canonical.entries.firstIndex(where: { $0.section == update.section && $0.key == update.key }) else {
+        notFound.append(NotFoundEntry(section: update.section, key: update.key))
+        continue
+      }
+      let rowIndex = canonical.entries[offset].sheetRow
+      let existingForms = canonical.entries[offset].translations.filter { !$0.value.isEmpty }.map { $0.key }
+      let defaultForm: String = {
+        if existingForms.count == 1, let only = existingForms.first { return only }
+        if existingForms.contains("one") { return "one" }
+        if existingForms.contains("other") { return "other" }
+        return PluralColumnLayout.detectDefaultForm(in: canonical.entries)
+      }()
+
+      let assignmentsByLang = Dictionary(grouping: update.assignments, by: \.language)
+      var cells: [UpdatedCell] = []
+      for sheet in sheets {
+        guard let assignments = assignmentsByLang[sheet.languageCode] else { continue }
+        for a in assignments {
+          let form = a.form ?? defaultForm
+          guard let column = PluralColumnLayout.column(forForm: form) else { continue }
+          edits.append(SheetBatchEdit(
+            sheetTab: sheet.language,
+            startRow: rowIndex,
+            startColumn: column,
+            rows: [[a.text]],
+            mode: .writeOnly
+          ))
+          cells.append(UpdatedCell(
+            tab: sheet.language,
+            column: GoogleSheetsWriter.columnLetters(forIndex: column),
+            form: form
+          ))
+        }
+      }
+      entries.append(UpdatedBatchEntry(
+        section: update.section,
+        key: update.key,
+        rowIndex: rowIndex,
+        cellsUpdated: cells
+      ))
+    }
+
+    if !edits.isEmpty {
+      try await writer.applyBatchEdits(edits)
+    }
+
+    return UpdatedBatch(
+      totalUpdated: entries.count,
+      items: entries,
+      notFound: notFound
     )
   }
 }

--- a/Sources/LinguaLib/Domain/UseCases/Localization/SheetDataLoader.swift
+++ b/Sources/LinguaLib/Domain/UseCases/Localization/SheetDataLoader.swift
@@ -3,4 +3,34 @@ import Foundation
 /// A protocol that defines the contract for loading sheet data
 public protocol SheetDataLoader {
   func loadSheets() async throws -> [LocalizationSheet]
+
+  /// Loads only the canonical language tab plus the names of every other tab. Used by
+  /// read-only commands (`find`, `sections`) that don't need every language's row data.
+  /// Concrete implementations can avoid fetching N tabs when this is called; the default
+  /// implementation in the protocol extension falls back to `loadSheets()` so test mocks
+  /// keep working unchanged.
+  func loadCanonicalSheet(preferred: String?) async throws -> CanonicalSheetLoad
+}
+
+public struct CanonicalSheetLoad: Equatable {
+  public let canonical: LocalizationSheet
+  public let allLanguageTabNames: [String]
+
+  public init(canonical: LocalizationSheet, allLanguageTabNames: [String]) {
+    self.canonical = canonical
+    self.allLanguageTabNames = allLanguageTabNames
+  }
+}
+
+public extension SheetDataLoader {
+  func loadCanonicalSheet(preferred: String?) async throws -> CanonicalSheetLoad {
+    let sheets = try await loadSheets()
+    guard let canonical = CanonicalSheetSelector.pick(from: sheets, preferred: preferred) else {
+      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
+    }
+    return CanonicalSheetLoad(
+      canonical: canonical,
+      allLanguageTabNames: sheets.map(\.language)
+    )
+  }
 }

--- a/Sources/LinguaLib/Infrastructure/Data/GoogleSheets/Fetcher/GoogleSheetDataLoader.swift
+++ b/Sources/LinguaLib/Infrastructure/Data/GoogleSheets/Fetcher/GoogleSheetDataLoader.swift
@@ -13,14 +13,28 @@ struct GoogleSheetDataLoader: SheetDataLoader {
   func loadSheets() async throws -> [LocalizationSheet] {
     let sheetMetadata = try await fetcher.fetchSheetNames()
     var sections = [LocalizationSheet]()
-    
+
     for sheet in sheetMetadata.sheets {
       let sheetName = sheet.properties.title
       let sheetDataResponse = try await fetcher.fetchSheetData(sheetName: sheetName)
       let section = sheetDataDecoder.decode(sheetData: sheetDataResponse, sheetName: sheetName)
       sections.append(section)
     }
-    
+
     return sections
+  }
+
+  /// Optimized canonical-only path: one metadata call + one data fetch for the canonical tab,
+  /// instead of one data fetch per language tab. Used by read-only commands (`find`, `sections`)
+  /// where the other tabs' row data is never read.
+  func loadCanonicalSheet(preferred: String?) async throws -> CanonicalSheetLoad {
+    let metadata = try await fetcher.fetchSheetNames()
+    let tabNames = metadata.sheets.map { $0.properties.title }
+    guard let canonicalTab = CanonicalSheetSelector.pickTabName(from: tabNames, preferred: preferred) else {
+      throw AgentError(code: "no_sheets", message: "No language sheets found in the spreadsheet.")
+    }
+    let response = try await fetcher.fetchSheetData(sheetName: canonicalTab)
+    let canonical = sheetDataDecoder.decode(sheetData: response, sheetName: canonicalTab)
+    return CanonicalSheetLoad(canonical: canonical, allLanguageTabNames: tabNames)
   }
 }

--- a/Sources/LinguaLib/Infrastructure/Data/GoogleSheets/Writer/GoogleSheetsWriter.swift
+++ b/Sources/LinguaLib/Infrastructure/Data/GoogleSheets/Writer/GoogleSheetsWriter.swift
@@ -3,6 +3,40 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// One slice of work to apply to a single tab as part of a batched edit. `startRow` is always
+/// expressed in the **original** 1-based row space of the sheet (the row number you would see
+/// in the Google Sheets UI before any edit in this batch has executed). The writer is
+/// responsible for translating that into the right index sequencing when multiple edits land
+/// in the same tab.
+struct SheetBatchEdit: Equatable {
+  enum Mode: Equatable {
+    /// Shift existing rows down by `rows.count` starting at `startRow`, then write `rows`.
+    /// Used when growing an existing section.
+    case insertRows
+    /// Write `rows` over the existing cells starting at `(startRow, startColumn)`. No row
+    /// insertion happens — useful for new sections appended past the last existing row, where
+    /// the cells are already blank, AND for in-place updates of specific cells (where
+    /// `startColumn` shifts the write window away from column A).
+    case writeOnly
+  }
+
+  let sheetTab: String
+  let startRow: Int
+  /// 1-based column at which `rows[*]` begin. Defaults to column A — only `update --batch`
+  /// uses anything other than 1 (to target the right plural-form column).
+  let startColumn: Int
+  let rows: [[String]]
+  let mode: Mode
+
+  init(sheetTab: String, startRow: Int, startColumn: Int = 1, rows: [[String]], mode: Mode) {
+    self.sheetTab = sheetTab
+    self.startRow = startRow
+    self.startColumn = startColumn
+    self.rows = rows
+    self.mode = mode
+  }
+}
+
 /// Public-ish protocol used by the agent use cases. The agent layer never speaks HTTP directly.
 protocol GoogleSheetsWriting {
   /// Insert a single blank row at `oneBasedRowIndex` in the given tab, then write `cells` into it.
@@ -22,6 +56,12 @@ protocol GoogleSheetsWriting {
   /// Delete a single row from the given tab. `oneBasedRowIndex` matches the row number you'd
   /// see in the Google Sheets UI.
   func deleteRow(sheetTab: String, oneBasedRowIndex: Int) async throws
+
+  /// Apply a list of edits across one or more tabs in a single Google Sheets `batchUpdate`
+  /// HTTP call. The implementation sequences the edits so each `startRow` is interpreted in
+  /// the original sheet's row space — callers can plan rows from a single pre-batch
+  /// `loadSheets()` snapshot without worrying about row drift between operations.
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws
 }
 
 final class GoogleSheetsWriter: GoogleSheetsWriting {
@@ -103,6 +143,73 @@ final class GoogleSheetsWriter: GoogleSheetsWriting {
       ]
     ]
     try await batchUpdate(body: body)
+  }
+
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws {
+    if edits.isEmpty { return }
+
+    // Resolve all tab gids in one metadata round trip (after the first call, the cache covers
+    // every tab in the spreadsheet so subsequent lookups are free).
+    for tab in Set(edits.map(\.sheetTab)) {
+      _ = try await sheetGid(forTab: tab)
+    }
+
+    // Ordering rules so every edit's `startRow` stays valid in the original row space:
+    //   1. All `writeOnly` edits (new sections at the bottom of the canonical sheet) execute
+    //      first. They overwrite still-blank cells past the last existing row, so they don't
+    //      perturb any row index above them.
+    //   2. `insertRows` edits then execute in DESCENDING `startRow` order. Each insertion at a
+    //      lower row shifts the rows below — but the higher-row insertions already completed
+    //      against their original positions, and the now-written `writeOnly` rows naturally
+    //      shift along with the rest of the sheet to their final destinations.
+    //
+    // Edits in different tabs are independent (different `sheetId`), so we don't need a
+    // per-tab grouping — the global sort is sufficient as long as the relative order within a
+    // tab is correct.
+    let writeOnlys = edits.filter { $0.mode == .writeOnly }
+    let inserts = edits.filter { $0.mode == .insertRows }
+      .sorted { $0.startRow > $1.startRow }
+    let ordered = writeOnlys + inserts
+
+    var requests: [[String: Any]] = []
+    for edit in ordered {
+      guard let gid = sheetGidCache[edit.sheetTab] else {
+        throw AgentError(
+          code: "sheet_tab_not_found",
+          message: "Could not find a tab named '\(edit.sheetTab)' in the spreadsheet."
+        )
+      }
+      let startIndex = edit.startRow - 1
+      let endIndex = startIndex + edit.rows.count
+
+      if edit.mode == .insertRows {
+        requests.append([
+          "insertDimension": [
+            "range": [
+              "sheetId": gid,
+              "dimension": "ROWS",
+              "startIndex": startIndex,
+              "endIndex": endIndex
+            ],
+            "inheritFromBefore": startIndex > 0
+          ]
+        ])
+      }
+
+      requests.append([
+        "updateCells": [
+          "rows": edit.rows.map { Self.rowDataPayload(cells: $0) },
+          "fields": "userEnteredValue",
+          "start": [
+            "sheetId": gid,
+            "rowIndex": startIndex,
+            "columnIndex": edit.startColumn - 1
+          ]
+        ]
+      ])
+    }
+
+    try await batchUpdate(body: ["requests": requests])
   }
 
   // MARK: - Helpers
@@ -203,5 +310,15 @@ final class GoogleSheetsWriter: GoogleSheetsWriting {
       n = (n - 1) / 26
     }
     return result
+  }
+
+  /// Builds the `RowData` payload one row at a time for `updateCells` requests. Each cell is
+  /// emitted as `userEnteredValue.stringValue` to match the existing `valueInputOption=RAW`
+  /// semantics — formulas in the text are not interpreted, mirroring `values.update`.
+  static func rowDataPayload(cells: [String]) -> [String: Any] {
+    let values: [[String: Any]] = cells.map { cell in
+      ["userEnteredValue": ["stringValue": cell]]
+    }
+    return ["values": values]
   }
 }

--- a/Tests/LinguaTests/Application/AI/LinguaAIInstallerTests.swift
+++ b/Tests/LinguaTests/Application/AI/LinguaAIInstallerTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import LinguaLib
+
+final class LinguaAIInstallerTests: XCTestCase {
+
+  // MARK: - LinguaAIInstallOption.bestMatch
+
+  func test_bestMatch_claudeAndCursor_returnsBoth() {
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: [.claudeCode, .cursor]), .both)
+    // Order shouldn't matter — bestMatch operates on a Set.
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: [.cursor, .claudeCode]), .both)
+  }
+
+  func test_bestMatch_claudeOnly_returnsClaude() {
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: [.claudeCode]), .claude)
+  }
+
+  func test_bestMatch_cursorOnly_returnsCursor() {
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: [.cursor]), .cursor)
+  }
+
+  func test_bestMatch_agentsOnly_returnsAgents() {
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: [.agents]), .agents)
+  }
+
+  func test_bestMatch_empty_returnsClaude() {
+    XCTAssertEqual(LinguaAIInstallOption.bestMatch(for: []), .claude)
+  }
+
+  func test_bestMatch_unrecognizedCombination_fallsBackToClaude() {
+    // Three targets together (claude + cursor + agents) doesn't match any explicit option →
+    // fallback path. This guards the "return .claude" tail of bestMatch.
+    XCTAssertEqual(
+      LinguaAIInstallOption.bestMatch(for: [.claudeCode, .cursor, .agents]),
+      .claude
+    )
+  }
+
+  // MARK: - LinguaAIInstallOption.targets
+
+  func test_option_targets_mapsExpectedTargets() {
+    XCTAssertEqual(LinguaAIInstallOption.claude.targets, [.claudeCode])
+    XCTAssertEqual(LinguaAIInstallOption.cursor.targets, [.cursor])
+    XCTAssertEqual(LinguaAIInstallOption.agents.targets, [.agents])
+    XCTAssertEqual(LinguaAIInstallOption.both.targets, [.claudeCode, .cursor])
+  }
+
+  // MARK: - Plural install / uninstall overloads (scope: option:)
+
+  func test_install_option_both_installsBothTargets() throws {
+    let projectDir = makeTempDir()
+    let installer = LinguaAIInstaller(homeDirectory: makeTempDir())
+
+    let results = try installer.install(
+      scope: .project,
+      option: .both,
+      force: false,
+      projectDirectory: projectDir
+    )
+
+    XCTAssertEqual(results.count, 2)
+    XCTAssertEqual(Set(results.map(\.target)), Set([LinguaAITarget.claudeCode.label, LinguaAITarget.cursor.label]))
+    for result in results {
+      XCTAssertEqual(Set(result.installed), Set(LinguaAIBundledSkills.all.map(\.name)))
+    }
+  }
+
+  func test_uninstall_option_both_removesBothTargets() throws {
+    let projectDir = makeTempDir()
+    let installer = LinguaAIInstaller(homeDirectory: makeTempDir())
+
+    _ = try installer.install(scope: .project, option: .both, force: false, projectDirectory: projectDir)
+    let removed = try installer.uninstall(scope: .project, option: .both, projectDirectory: projectDir)
+
+    XCTAssertEqual(removed.count, 2)
+    for status in removed {
+      XCTAssertEqual(Set(status.installed), Set(LinguaAIBundledSkills.all.map(\.name)))
+    }
+  }
+
+  // MARK: - LinguaAIStatusReport accessors
+
+  func test_statusReport_globalStatuses_returnsAllGlobalScopes() {
+    let report = makeReport(
+      claudeCodeProject: makeStatus(target: .claudeCode, scope: .project, installed: []),
+      claudeCodeGlobal: makeStatus(target: .claudeCode, scope: .global, installed: ["x"]),
+      cursorProject: makeStatus(target: .cursor, scope: .project, installed: []),
+      cursorGlobal: makeStatus(target: .cursor, scope: .global, installed: ["y"]),
+      agentsProject: makeStatus(target: .agents, scope: .project, installed: []),
+      agentsGlobal: makeStatus(target: .agents, scope: .global, installed: ["z"])
+    )
+
+    XCTAssertEqual(
+      report.globalStatuses.map(\.target),
+      [LinguaAITarget.claudeCode.label, LinguaAITarget.cursor.label, LinguaAITarget.agents.label]
+    )
+    XCTAssertEqual(report.globalStatuses.map(\.installed), [["x"], ["y"], ["z"]])
+  }
+
+  func test_statusReport_hasProjectInstallations_isFalse_whenAllProjectScopesEmpty() {
+    let report = makeReport(
+      claudeCodeProject: makeStatus(target: .claudeCode, scope: .project, installed: []),
+      cursorProject: makeStatus(target: .cursor, scope: .project, installed: []),
+      agentsProject: makeStatus(target: .agents, scope: .project, installed: [])
+    )
+
+    XCTAssertFalse(report.hasProjectInstallations)
+    XCTAssertEqual(report.projectInstallationState, .notInstalled)
+    XCTAssertEqual(report.projectInstalledTargets, [])
+  }
+
+  func test_statusReport_hasProjectInstallations_isTrue_whenAnyProjectScopeHasInstalls() {
+    let report = makeReport(
+      claudeCodeProject: makeStatus(target: .claudeCode, scope: .project, installed: ["one"]),
+      cursorProject: makeStatus(target: .cursor, scope: .project, installed: []),
+      agentsProject: makeStatus(target: .agents, scope: .project, installed: [])
+    )
+
+    XCTAssertTrue(report.hasProjectInstallations)
+  }
+
+  // MARK: - Helpers
+
+  private func makeTempDir() -> URL {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: dir)
+    }
+    return dir
+  }
+
+  private func makeStatus(
+    target: LinguaAITarget,
+    scope: LinguaAIInstallScope,
+    installed: [String]
+  ) -> LinguaAIScopeStatus {
+    LinguaAIScopeStatus(
+      target: target.label,
+      scope: scope.label,
+      directory: "/tmp/\(target.label)/\(scope.label)",
+      installed: installed
+    )
+  }
+
+  /// Fills missing arguments with empty-scope defaults so each test only specifies what matters.
+  private func makeReport(
+    claudeCodeProject: LinguaAIScopeStatus? = nil,
+    claudeCodeGlobal: LinguaAIScopeStatus? = nil,
+    cursorProject: LinguaAIScopeStatus? = nil,
+    cursorGlobal: LinguaAIScopeStatus? = nil,
+    agentsProject: LinguaAIScopeStatus? = nil,
+    agentsGlobal: LinguaAIScopeStatus? = nil
+  ) -> LinguaAIStatusReport {
+    LinguaAIStatusReport(
+      claudeCodeProject: claudeCodeProject ?? makeStatus(target: .claudeCode, scope: .project, installed: []),
+      claudeCodeGlobal: claudeCodeGlobal ?? makeStatus(target: .claudeCode, scope: .global, installed: []),
+      cursorProject: cursorProject ?? makeStatus(target: .cursor, scope: .project, installed: []),
+      cursorGlobal: cursorGlobal ?? makeStatus(target: .cursor, scope: .global, installed: []),
+      agentsProject: agentsProject ?? makeStatus(target: .agents, scope: .project, installed: []),
+      agentsGlobal: agentsGlobal ?? makeStatus(target: .agents, scope: .global, installed: [])
+    )
+  }
+}

--- a/Tests/LinguaTests/Application/CommandLineParser/CommandLineParserTests.swift
+++ b/Tests/LinguaTests/Application/CommandLineParser/CommandLineParserTests.swift
@@ -79,6 +79,72 @@ final class CommandLineParserTests: XCTestCase {
     XCTAssertEqual(parsed.flags["limit"], "5")
   }
 
+  func test_parse_findCommand_collectsMultiplePositionalQueries() throws {
+    let parsed = try sut.parse(arguments: [
+      "Lingua", "find", "config.json",
+      "Settings", "Account", "Display name"
+    ])
+    XCTAssertEqual(parsed.command, .find)
+    XCTAssertEqual(parsed.positional, ["Settings", "Account", "Display name"])
+  }
+
+  func test_parse_subcommand_helpBeforeConfig_returnsHelpFlagInsteadOfPathError() throws {
+    // Per-subcommand --help shouldn't insist on a config path. Regression for the
+    // "Invalid config file path. Must end with '.json'." wart that ate agent turns.
+    for form in ["--help", "-h", "help"] {
+      let parsed = try sut.parse(arguments: ["Lingua", "add", form])
+      XCTAssertEqual(parsed.command, .add)
+      XCTAssertTrue(parsed.booleanFlags.contains("help"), "form: \(form)")
+    }
+  }
+
+  func test_parse_subcommand_helpAfterConfig_setsHelpFlag() throws {
+    // `lingua add ./config.json --help` also short-circuits — the dispatcher checks the
+    // help flag before requiring --section / --key.
+    let parsed = try sut.parse(arguments: ["Lingua", "add", "./config.json", "--help"])
+    XCTAssertEqual(parsed.command, .add)
+    XCTAssertEqual(parsed.configFilePath, "./config.json")
+    XCTAssertTrue(parsed.booleanFlags.contains("help"))
+  }
+
+  func test_parse_aiHelp_acceptsHelpInsteadOfSubcommand() throws {
+    for form in ["--help", "-h", "help"] {
+      let parsed = try sut.parse(arguments: ["Lingua", "ai", form])
+      XCTAssertEqual(parsed.command, .ai)
+      XCTAssertTrue(parsed.booleanFlags.contains("help"), "form: \(form)")
+    }
+  }
+
+  func test_parse_booleanFlagsDoNotSwallowFollowingToken() throws {
+    // Regression: `lingua add ./config.json --batch /tmp/x.json --new-section Settings` used
+    // to silently set flags["new-section"] = "Settings" and leave booleanFlags empty, so
+    // the use case never knew to allow a new section. With the boolean-flag whitelist the
+    // trailing `Settings` falls through as a stray positional arg and `new-section` stays
+    // a true boolean.
+    let parsed = try sut.parse(arguments: [
+      "Lingua", "add", "config.json",
+      "--batch", "/tmp/x.json",
+      "--new-section", "Settings"
+    ])
+    XCTAssertEqual(parsed.flags["batch"], "/tmp/x.json")
+    XCTAssertTrue(parsed.booleanFlags.contains("new-section"))
+    XCTAssertNil(parsed.flags["new-section"])
+    XCTAssertEqual(parsed.positional, ["Settings"])
+  }
+
+  func test_parse_addCommand_acceptsBatchAndSyncFlags() throws {
+    let parsed = try sut.parse(arguments: [
+      "Lingua", "add", "config.json",
+      "--batch", "/tmp/payload.json",
+      "--new-section",
+      "--sync", "ios,android"
+    ])
+    XCTAssertEqual(parsed.command, .add)
+    XCTAssertEqual(parsed.flags["batch"], "/tmp/payload.json")
+    XCTAssertEqual(parsed.flags["sync"], "ios,android")
+    XCTAssertTrue(parsed.booleanFlags.contains("new-section"))
+  }
+
   func test_parse_addCommand_collectsMultiValueFlags() throws {
     let parsed = try sut.parse(arguments: [
       "Lingua", "add", "config.json",

--- a/Tests/LinguaTests/Application/Processor/AgentCommandDispatcherTests.swift
+++ b/Tests/LinguaTests/Application/Processor/AgentCommandDispatcherTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+import LinguaLib
+@testable import Lingua
+
+final class AgentCommandDispatcherTests: XCTestCase {
+
+  // MARK: - parseValueFlags
+
+  func test_parseValueFlags_parsesLanguageOnlyForm() throws {
+    let sut = makeSUT()
+    let result = try sut.parseValueFlags(["en=Hello"])
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].language, "en")
+    XCTAssertNil(result[0].form)
+    XCTAssertEqual(result[0].text, "Hello")
+  }
+
+  func test_parseValueFlags_parsesLanguageAndForm() throws {
+    let sut = makeSUT()
+    let result = try sut.parseValueFlags(["en:other=%d items"])
+    XCTAssertEqual(result[0].language, "en")
+    XCTAssertEqual(result[0].form, "other")
+    XCTAssertEqual(result[0].text, "%d items")
+  }
+
+  func test_parseValueFlags_preservesEqualsInsideText() throws {
+    let sut = makeSUT()
+    let result = try sut.parseValueFlags(["en=a=b"])
+    XCTAssertEqual(result[0].text, "a=b")
+  }
+
+  func test_parseValueFlags_throwsInvalidValue_whenNoEquals() {
+    let sut = makeSUT()
+    assertAgentError(code: "invalid_value") {
+      _ = try sut.parseValueFlags(["enHello"])
+    }
+  }
+
+  func test_parseValueFlags_throwsInvalidValue_whenLanguageEmpty() {
+    let sut = makeSUT()
+    assertAgentError(code: "invalid_value") {
+      _ = try sut.parseValueFlags(["=Hello"])
+    }
+  }
+
+  // MARK: - buildNewTranslation / buildTranslationUpdate
+
+  func test_buildNewTranslation_returnsTranslation_whenAllFlagsPresent() throws {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .add,
+      flags: ["section": "welcome", "key": "title"],
+      multiValueFlags: ["value": ["en=Hello"]],
+      booleanFlags: ["new-section", "dry-run"]
+    )
+    let translation = try sut.buildNewTranslation(args)
+    XCTAssertEqual(translation.section, "welcome")
+    XCTAssertEqual(translation.key, "title")
+    XCTAssertEqual(translation.assignments.count, 1)
+    XCTAssertTrue(translation.allowNewSection)
+    XCTAssertTrue(translation.dryRun)
+  }
+
+  func test_buildNewTranslation_throwsMissingArgument_whenSectionMissing() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .add,
+      flags: ["key": "title"],
+      multiValueFlags: ["value": ["en=Hello"]]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildNewTranslation(args) }
+  }
+
+  func test_buildNewTranslation_throwsMissingArgument_whenKeyMissing() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .add,
+      flags: ["section": "welcome"],
+      multiValueFlags: ["value": ["en=Hello"]]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildNewTranslation(args) }
+  }
+
+  func test_buildNewTranslation_throwsMissingArgument_whenNoValues() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .add,
+      flags: ["section": "welcome", "key": "title"]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildNewTranslation(args) }
+  }
+
+  func test_buildTranslationUpdate_returnsUpdate_whenAllFlagsPresent() throws {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .update,
+      flags: ["section": "welcome", "key": "title"],
+      multiValueFlags: ["value": ["en=Hello", "de:other=Hallo"]]
+    )
+    let update = try sut.buildTranslationUpdate(args)
+    XCTAssertEqual(update.section, "welcome")
+    XCTAssertEqual(update.key, "title")
+    XCTAssertEqual(update.assignments.count, 2)
+  }
+
+  func test_buildTranslationUpdate_throwsMissingArgument_whenSectionMissing() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .update,
+      flags: ["key": "title"],
+      multiValueFlags: ["value": ["en=Hello"]]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildTranslationUpdate(args) }
+  }
+
+  func test_buildTranslationUpdate_throwsMissingArgument_whenKeyMissing() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .update,
+      flags: ["section": "welcome"],
+      multiValueFlags: ["value": ["en=Hello"]]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildTranslationUpdate(args) }
+  }
+
+  func test_buildTranslationUpdate_throwsMissingArgument_whenNoValues() {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .update,
+      flags: ["section": "welcome", "key": "title"]
+    )
+    assertAgentError(code: "missing_argument") { _ = try sut.buildTranslationUpdate(args) }
+  }
+
+  // MARK: - maybeRunSync
+
+  func test_maybeRunSync_isNoOp_whenFlagAbsent() async throws {
+    let module = MockLocalizationModule(errorMessage: nil)
+    let sut = makeSUT(moduleFactory: { _ in module })
+
+    try await sut.maybeRunSync(args: CommandLineArguments(command: .add), config: makeConfig())
+
+    XCTAssertTrue(module.messages.isEmpty)
+  }
+
+  func test_maybeRunSync_runsSinglePlatform() async throws {
+    let module = MockLocalizationModule(errorMessage: nil)
+    let sut = makeSUT(moduleFactory: { _ in module })
+
+    let args = CommandLineArguments(command: .add, flags: ["sync": "ios"])
+    try await sut.maybeRunSync(args: args, config: makeConfig())
+
+    XCTAssertEqual(module.messages, [.localize(.ios)])
+  }
+
+  func test_maybeRunSync_runsMultiplePlatforms_andDeduplicates() async throws {
+    let module = MockLocalizationModule(errorMessage: nil)
+    let sut = makeSUT(moduleFactory: { _ in module })
+
+    let args = CommandLineArguments(command: .add, flags: ["sync": "ios, android , ios"])
+    try await sut.maybeRunSync(args: args, config: makeConfig())
+
+    XCTAssertEqual(module.messages, [.localize(.ios), .localize(.android)])
+  }
+
+  func test_maybeRunSync_throwsInvalidSync_onUnknownPlatform() async {
+    let sut = makeSUT()
+    let args = CommandLineArguments(command: .add, flags: ["sync": "windows"])
+    await assertAgentErrorAsync(code: "invalid_sync_value") {
+      try await sut.maybeRunSync(args: args, config: makeConfig())
+    }
+  }
+
+  // MARK: - loadConfig
+
+  func test_loadConfig_throwsMissingConfig_whenPathNil() async {
+    let sut = makeSUT()
+    let args = CommandLineArguments(command: .sections, configFilePath: nil)
+    await assertAgentErrorAsync(code: "missing_config") {
+      _ = try await sut.loadConfig(args)
+    }
+  }
+
+  func test_loadConfig_returnsLocalization_whenFileHasLocalization() async throws {
+    let url = writeTempConfig(json: """
+    {
+      "localization": {
+        "apiKey": "key",
+        "sheetId": "sheet",
+        "outputDirectory": "out"
+      }
+    }
+    """)
+    let sut = makeSUT()
+    let args = CommandLineArguments(command: .sections, configFilePath: url.path)
+
+    let localization = try await sut.loadConfig(args)
+
+    XCTAssertEqual(localization.apiKey, "key")
+    XCTAssertEqual(localization.sheetId, "sheet")
+    XCTAssertEqual(localization.outputDirectory, "out")
+  }
+
+  func test_loadConfig_throwsMissingLocalization_whenFileLacksLocalization() async throws {
+    let url = writeTempConfig(json: "{}")
+    let sut = makeSUT()
+    let args = CommandLineArguments(command: .sections, configFilePath: url.path)
+    await assertAgentErrorAsync(code: "missing_localization") {
+      _ = try await sut.loadConfig(args)
+    }
+  }
+
+  // MARK: - dispatch: --help short-circuit
+
+  func test_dispatch_help_returnsWithoutLoadingConfig() async throws {
+    // No configFilePath provided — if dispatch tried to load config it would call exit(1).
+    // Reaching the end of this test without crashing proves the help branch short-circuited.
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .sections,
+      configFilePath: nil,
+      booleanFlags: ["help"]
+    )
+    try await sut.dispatch(args)
+  }
+
+  func test_dispatch_helpShort_returnsWithoutLoadingConfig() async throws {
+    let sut = makeSUT()
+    let args = CommandLineArguments(
+      command: .sections,
+      configFilePath: nil,
+      booleanFlags: ["h"]
+    )
+    try await sut.dispatch(args)
+  }
+
+  // MARK: - Helpers
+
+  private func makeSUT(
+    moduleFactory: @escaping (Config.Localization) -> ModuleLocalizing = { _ in
+      MockLocalizationModule(errorMessage: nil)
+    }
+  ) -> AgentCommandDispatcher {
+    AgentCommandDispatcher(
+      entityFileLoader: EntityLoaderFactory.makeConfigLoader(),
+      localizationModuleFactory: moduleFactory,
+      agentFactory: AgentModuleFactory(),
+      output: AgentJSONOutput()
+    )
+  }
+
+  private func makeConfig() -> Config.Localization {
+    Config.Localization(
+      apiKey: "key",
+      sheetId: "sheet",
+      outputDirectory: "out",
+      localizedSwiftCode: nil
+    )
+  }
+
+  private func writeTempConfig(json: String) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("\(UUID().uuidString).json")
+    try? json.data(using: .utf8)?.write(to: url)
+    addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+    return url
+  }
+
+  private func assertAgentError(
+    code expectedCode: String,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ block: () throws -> Void
+  ) {
+    do {
+      try block()
+      XCTFail("Expected AgentError(\(expectedCode))", file: file, line: line)
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, expectedCode, file: file, line: line)
+    } catch {
+      XCTFail("Wrong error type: \(error)", file: file, line: line)
+    }
+  }
+
+  private func assertAgentErrorAsync(
+    code expectedCode: String,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ block: () async throws -> Void
+  ) async {
+    do {
+      try await block()
+      XCTFail("Expected AgentError(\(expectedCode))", file: file, line: line)
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, expectedCode, file: file, line: line)
+    } catch {
+      XCTFail("Wrong error type: \(error)", file: file, line: line)
+    }
+  }
+}

--- a/Tests/LinguaTests/Application/Processor/BatchFileLoaderTests.swift
+++ b/Tests/LinguaTests/Application/Processor/BatchFileLoaderTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import LinguaLib
+@testable import Lingua
+
+final class BatchFileLoaderTests: XCTestCase {
+
+  func test_loadAddBatch_parsesPlainAndPluralValues() throws {
+    let url = writeTempFile(contents: """
+    [
+      {"section": "Settings", "key": "title", "values": {"en": "Settings", "de": "Einstellungen"}},
+      {"section": "Cart", "key": "item_count", "values": {
+        "en": {"one": "1 item", "other": "%d items"},
+        "de": {"one": "1 Artikel", "other": "%d Artikel"}
+      }}
+    ]
+    """)
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let batch = try BatchFileLoader.loadAddBatch(path: url.path, allowNewSections: true, dryRun: false)
+    XCTAssertEqual(batch.items.count, 2)
+    XCTAssertTrue(batch.allowNewSections)
+    XCTAssertFalse(batch.dryRun)
+
+    let plain = batch.items[0]
+    XCTAssertEqual(plain.section, "Settings")
+    XCTAssertEqual(plain.key, "title")
+    XCTAssertEqual(Set(plain.assignments.map(\.language)), ["en", "de"])
+    XCTAssertTrue(plain.assignments.allSatisfy { $0.form == nil })
+
+    let plural = batch.items[1]
+    let englishForms = plural.assignments.filter { $0.language == "en" }.compactMap { $0.form }
+    XCTAssertEqual(Set(englishForms), ["one", "other"])
+    let englishOther = plural.assignments.first { $0.language == "en" && $0.form == "other" }
+    XCTAssertEqual(englishOther?.text, "%d items")
+  }
+
+  func test_loadAddBatch_invalidJson_throwsAgentError() {
+    let url = writeTempFile(contents: "not actually json")
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    do {
+      _ = try BatchFileLoader.loadAddBatch(path: url.path, allowNewSections: false, dryRun: false)
+      XCTFail("expected batch_file_invalid")
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, "batch_file_invalid")
+    } catch {
+      XCTFail("expected AgentError, got \(error)")
+    }
+  }
+
+  func test_loadAddBatch_missingFile_throwsAgentError() {
+    do {
+      _ = try BatchFileLoader.loadAddBatch(path: "/tmp/does-not-exist-\(UUID().uuidString).json", allowNewSections: false, dryRun: false)
+      XCTFail("expected batch_file_unreadable")
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, "batch_file_unreadable")
+    } catch {
+      XCTFail("expected AgentError, got \(error)")
+    }
+  }
+
+  func test_loadUpdateBatch_parsesIntoTranslationUpdates() throws {
+    let url = writeTempFile(contents: """
+    [
+      {"section": "Settings", "key": "title", "values": {"en": "Preferences"}}
+    ]
+    """)
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let updates = try BatchFileLoader.loadUpdateBatch(path: url.path)
+    XCTAssertEqual(updates.count, 1)
+    XCTAssertEqual(updates[0].section, "Settings")
+    XCTAssertEqual(updates[0].key, "title")
+    XCTAssertEqual(updates[0].assignments.first?.text, "Preferences")
+  }
+
+  // MARK: - Helpers
+
+  private func writeTempFile(contents: String) -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+    try? contents.data(using: .utf8)?.write(to: url)
+    return url
+  }
+}

--- a/Tests/LinguaTests/Domain/UseCases/Agent/AddTranslationUseCaseTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/AddTranslationUseCaseTests.swift
@@ -431,6 +431,7 @@ private final class SpyWriter: GoogleSheetsWriting {
   var appends: [Append] = []
   var cellUpdates: [(tab: String, row: Int, col: Int, value: String)] = []
   var deletes: [(tab: String, row: Int)] = []
+  var batchEdits: [SheetBatchEdit] = []
 
   func insertRow(sheetTab: String, oneBasedRowIndex: Int, cells: [String]) async throws {
     inserts.append(.init(tab: sheetTab, row: oneBasedRowIndex, cells: cells))
@@ -446,5 +447,8 @@ private final class SpyWriter: GoogleSheetsWriting {
   }
   func deleteRow(sheetTab: String, oneBasedRowIndex: Int) async throws {
     deletes.append((sheetTab, oneBasedRowIndex))
+  }
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws {
+    batchEdits.append(contentsOf: edits)
   }
 }

--- a/Tests/LinguaTests/Domain/UseCases/Agent/BatchTranslationsTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/BatchTranslationsTests.swift
@@ -1,0 +1,305 @@
+import XCTest
+@testable import LinguaLib
+
+final class BatchTranslationsTests: XCTestCase {
+
+  // MARK: - addBatch
+
+  func test_addBatch_singleSection_insertsAllItemsAsOneBlock() async throws {
+    let sheets = makeSheets(entries: [
+      ("welcome", "title", 2),
+      ("welcome", "subtitle", 3),
+      ("onboarding", "step_1", 4)
+    ])
+    let writer = SpyBatchWriter()
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.addBatch(AddTranslationBatch(
+      items: [
+        item(section: "onboarding", key: "step_2", en: "Two", de: "Zwei"),
+        item(section: "onboarding", key: "step_3", en: "Three", de: "Drei")
+      ],
+      allowNewSections: false,
+      dryRun: false
+    ))
+
+    XCTAssertEqual(result.totalAdded, 2)
+    XCTAssertEqual(result.items.map(\.rowIndex), [5, 6])
+    XCTAssertTrue(result.createdSections.isEmpty)
+
+    // 2 tabs × 1 block each = 2 edits. Each is an insertRows with 2 rows.
+    XCTAssertEqual(writer.received.count, 2)
+    for edit in writer.received {
+      XCTAssertEqual(edit.mode, .insertRows)
+      XCTAssertEqual(edit.startRow, 5)
+      XCTAssertEqual(edit.rows.count, 2)
+    }
+  }
+
+  func test_addBatch_newSection_writesOnly_withSeparator() async throws {
+    let sheets = makeSheets(entries: [
+      ("welcome", "title", 2),
+      ("welcome", "subtitle", 3)
+    ])
+    let writer = SpyBatchWriter()
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.addBatch(AddTranslationBatch(
+      items: [
+        item(section: "settings", key: "title", en: "Settings", de: "Einstellungen"),
+        item(section: "settings", key: "account", en: "Account", de: "Konto")
+      ],
+      allowNewSections: true,
+      dryRun: false
+    ))
+
+    XCTAssertEqual(result.createdSections, ["settings"])
+    // Last existing row = 3. New section starts at 3 + 2 = 5 (leaves row 4 blank as separator).
+    XCTAssertEqual(result.items.map(\.rowIndex), [5, 6])
+    for edit in writer.received {
+      XCTAssertEqual(edit.mode, .writeOnly)
+      XCTAssertEqual(edit.startRow, 5)
+    }
+  }
+
+  func test_addBatch_mixedExistingAndNew_plansEachIndependently() async throws {
+    let sheets = makeSheets(entries: [
+      ("welcome", "title", 2),
+      ("welcome", "subtitle", 3),
+      ("errors", "generic", 4)
+    ])
+    let writer = SpyBatchWriter()
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.addBatch(AddTranslationBatch(
+      items: [
+        item(section: "welcome", key: "tagline", en: "Hi", de: "Hi"),
+        item(section: "settings", key: "title", en: "Settings", de: "Einstellungen")
+      ],
+      allowNewSections: true,
+      dryRun: false
+    ))
+
+    // welcome was at rows 2-3, so the new item slots in at row 4 (existing-section insert).
+    // settings is new, lands at lastOverall(4) + 2 = 6.
+    XCTAssertEqual(result.items.first(where: { $0.key == "tagline" })?.rowIndex, 4)
+    XCTAssertEqual(result.items.first(where: { $0.key == "title" })?.rowIndex, 6)
+    XCTAssertEqual(result.createdSections, ["settings"])
+
+    let writeOnly = writer.received.filter { $0.mode == .writeOnly }
+    let insertRows = writer.received.filter { $0.mode == .insertRows }
+    XCTAssertEqual(writeOnly.count, 2, "one writeOnly per tab for the new section")
+    XCTAssertEqual(insertRows.count, 2, "one insertRows per tab for the existing section")
+  }
+
+  func test_addBatch_rejectsInBatchDuplicate() async throws {
+    let sheets = makeSheets(entries: [("welcome", "title", 2)])
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyBatchWriter(),
+      preferredSheet: "en_US_English"
+    )
+
+    do {
+      _ = try await sut.addBatch(AddTranslationBatch(
+        items: [
+          item(section: "welcome", key: "subtitle", en: "A", de: "A"),
+          item(section: "welcome", key: "subtitle", en: "B", de: "B")
+        ],
+        allowNewSections: false,
+        dryRun: false
+      ))
+      XCTFail("expected duplicate_key")
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, "duplicate_key")
+    }
+  }
+
+  func test_addBatch_unknownSection_withoutAllowNew_returnsSuggestions() async throws {
+    let sheets = makeSheets(entries: [
+      ("settings", "title", 2),
+      ("onboarding", "step_1", 3)
+    ])
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyBatchWriter(),
+      preferredSheet: "en_US_English"
+    )
+
+    do {
+      _ = try await sut.addBatch(AddTranslationBatch(
+        items: [item(section: "setings", key: "x", en: "A", de: "A")],
+        allowNewSections: false,
+        dryRun: false
+      ))
+      XCTFail("expected unknown_section")
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, "unknown_section")
+      XCTAssertTrue(error.details?["suggestions"]?.contains("settings") ?? false)
+    }
+  }
+
+  func test_addBatch_dryRun_doesNotWrite() async throws {
+    let sheets = makeSheets(entries: [("welcome", "title", 2)])
+    let writer = SpyBatchWriter()
+    let sut = AddTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.addBatch(AddTranslationBatch(
+      items: [item(section: "welcome", key: "subtitle", en: "Hi", de: "Hallo")],
+      allowNewSections: false,
+      dryRun: true
+    ))
+
+    XCTAssertTrue(result.dryRun)
+    XCTAssertTrue(writer.received.isEmpty)
+  }
+
+  // MARK: - updateBatch
+
+  func test_updateBatch_targetsCorrectColumnsPerLanguage() async throws {
+    let sheets = makeSheets(entries: [
+      ("settings", "title", 2),
+      ("settings", "account", 3)
+    ])
+    let writer = SpyBatchWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.updateBatch([
+      TranslationUpdate(
+        section: "settings",
+        key: "title",
+        assignments: [
+          ValueAssignment(language: "en", form: nil, text: "Preferences"),
+          ValueAssignment(language: "de", form: nil, text: "Voreinstellungen")
+        ]
+      )
+    ])
+
+    XCTAssertEqual(result.totalUpdated, 1)
+    XCTAssertTrue(result.notFound.isEmpty)
+    XCTAssertEqual(writer.received.count, 2, "one edit per language tab")
+    for edit in writer.received {
+      XCTAssertEqual(edit.mode, .writeOnly)
+      XCTAssertEqual(edit.startRow, 2)
+      // Existing rows have `one` populated → default form column D (1-based 4).
+      XCTAssertEqual(edit.startColumn, 4)
+      XCTAssertEqual(edit.rows.count, 1)
+      XCTAssertEqual(edit.rows[0].count, 1)
+    }
+  }
+
+  func test_updateBatch_collectsNotFound_withoutAborting() async throws {
+    let sheets = makeSheets(entries: [("settings", "title", 2)])
+    let writer = SpyBatchWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.updateBatch([
+      TranslationUpdate(
+        section: "settings",
+        key: "title",
+        assignments: [ValueAssignment(language: "en", form: nil, text: "Preferences")]
+      ),
+      TranslationUpdate(
+        section: "settings",
+        key: "ghost",
+        assignments: [ValueAssignment(language: "en", form: nil, text: "Nope")]
+      )
+    ])
+
+    XCTAssertEqual(result.totalUpdated, 1)
+    XCTAssertEqual(result.notFound.count, 1)
+    XCTAssertEqual(result.notFound[0].key, "ghost")
+  }
+
+  func test_updateBatch_explicitPluralForm_targetsThatColumn() async throws {
+    let sheets = [
+      LocalizationSheet(language: "en_US_English", entries: [
+        LocalizationEntry(section: "cart", key: "item_count", translations: ["one": "1 item", "other": "%d items"], sheetRow: 2)
+      ]),
+      LocalizationSheet(language: "de_DE_German", entries: [
+        LocalizationEntry(section: "cart", key: "item_count", translations: ["one": "1 Artikel", "other": "%d Artikel"], sheetRow: 2)
+      ])
+    ]
+    let writer = SpyBatchWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    _ = try await sut.updateBatch([
+      TranslationUpdate(
+        section: "cart",
+        key: "item_count",
+        assignments: [ValueAssignment(language: "en", form: "other", text: "%d things")]
+      )
+    ])
+
+    XCTAssertEqual(writer.received.count, 1)
+    // `other` is column H = 1-based 8.
+    XCTAssertEqual(writer.received[0].startColumn, 8)
+    XCTAssertEqual(writer.received[0].rows[0], ["%d things"])
+  }
+
+  // MARK: - Helpers
+
+  private func makeSheets(entries: [(String, String, Int)]) -> [LocalizationSheet] {
+    let build: (String) -> LocalizationSheet = { lang in
+      LocalizationSheet(
+        language: lang,
+        entries: entries.map { LocalizationEntry(section: $0.0, key: $0.1, translations: ["one": "x"], sheetRow: $0.2) }
+      )
+    }
+    return [build("en_US_English"), build("de_DE_German")]
+  }
+
+  private func item(section: String, key: String, en: String, de: String) -> NewTranslationBatchItem {
+    NewTranslationBatchItem(
+      section: section,
+      key: key,
+      assignments: [
+        ValueAssignment(language: "en", form: nil, text: en),
+        ValueAssignment(language: "de", form: nil, text: de)
+      ]
+    )
+  }
+}
+
+// MARK: - Spy
+
+private final class SpyBatchWriter: GoogleSheetsWriting {
+  var received: [SheetBatchEdit] = []
+
+  func insertRow(sheetTab: String, oneBasedRowIndex: Int, cells: [String]) async throws {}
+  func updateRow(sheetTab: String, oneBasedRowIndex: Int, cells: [String]) async throws {}
+  func appendRow(sheetTab: String, cells: [String]) async throws {}
+  func updateCell(sheetTab: String, oneBasedRow: Int, oneBasedColumn: Int, value: String) async throws {}
+  func deleteRow(sheetTab: String, oneBasedRowIndex: Int) async throws {}
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws {
+    received.append(contentsOf: edits)
+  }
+}

--- a/Tests/LinguaTests/Domain/UseCases/Agent/CanonicalSheetSelectorTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/CanonicalSheetSelectorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import LinguaLib
+
+final class CanonicalSheetSelectorTests: XCTestCase {
+
+  // MARK: - pickTabName
+
+  func test_pickTabName_returnsPreferred_whenPresent() {
+    let tabs = ["en_US_English", "de_DE_German", "fr_FR_French"]
+    XCTAssertEqual(CanonicalSheetSelector.pickTabName(from: tabs, preferred: "de_DE_German"), "de_DE_German")
+  }
+
+  func test_pickTabName_fallsBackToEnglish_whenPreferredMissing() {
+    let tabs = ["de_DE_German", "en_US_English", "fr_FR_French"]
+    XCTAssertEqual(CanonicalSheetSelector.pickTabName(from: tabs, preferred: nil), "en_US_English")
+  }
+
+  func test_pickTabName_fallsBackToEnglish_whenPreferredNotInTabs() {
+    let tabs = ["de_DE_German", "en_US_English"]
+    XCTAssertEqual(CanonicalSheetSelector.pickTabName(from: tabs, preferred: "es_ES_Spanish"), "en_US_English")
+  }
+
+  func test_pickTabName_returnsFirstTab_whenNoEnglish() {
+    let tabs = ["de_DE_German", "fr_FR_French"]
+    XCTAssertEqual(CanonicalSheetSelector.pickTabName(from: tabs, preferred: nil), "de_DE_German")
+  }
+
+  func test_pickTabName_returnsNil_whenEmpty() {
+    XCTAssertNil(CanonicalSheetSelector.pickTabName(from: [], preferred: nil))
+    XCTAssertNil(CanonicalSheetSelector.pickTabName(from: [], preferred: "en_US_English"))
+  }
+
+  // MARK: - languageCode(forTabName:)
+
+  func test_languageCode_stripsSuffix_afterUnderscore() {
+    XCTAssertEqual(CanonicalSheetSelector.languageCode(forTabName: "en_US_English"), "en")
+    XCTAssertEqual(CanonicalSheetSelector.languageCode(forTabName: "zh-Hant_TW_Chinese"), "zh-Hant")
+  }
+
+  func test_languageCode_returnsWhole_whenNoUnderscore() {
+    XCTAssertEqual(CanonicalSheetSelector.languageCode(forTabName: "en"), "en")
+  }
+}

--- a/Tests/LinguaTests/Domain/UseCases/Agent/DeleteTranslationUseCaseTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/DeleteTranslationUseCaseTests.swift
@@ -82,4 +82,5 @@ private final class SpyWriter: GoogleSheetsWriting {
   func deleteRow(sheetTab: String, oneBasedRowIndex: Int) async throws {
     deletes.append((sheetTab, oneBasedRowIndex))
   }
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws {}
 }

--- a/Tests/LinguaTests/Domain/UseCases/Agent/FindAndSectionsTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/FindAndSectionsTests.swift
@@ -68,6 +68,50 @@ final class FindAndSectionsTests: XCTestCase {
     // The sheet was loaded exactly once — the whole point of the multi-query path.
     XCTAssertEqual(loader.loadCount, 1)
   }
+
+  func test_findTranslation_partialKeyMatch_scoresEighty() async throws {
+    // No exact key/value match — only the substring-in-key branch ("hello_button" contains "hello_b").
+    // The English value ("Press me") doesn't contain the query either, so the score-80 branch
+    // is the only one that fires.
+    let sheets = [
+      LocalizationSheet(language: "en_US_English", entries: [
+        LocalizationEntry(section: "welcome", key: "hello_button", translations: ["other": "Press me"])
+      ])
+    ]
+    let sut = FindTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      preferredSheet: nil
+    )
+
+    let result = try await sut.find(query: "hello_b", limit: 10)
+
+    XCTAssertEqual(result.matches.count, 1)
+    XCTAssertEqual(result.matches[0].score, 80)
+    XCTAssertEqual(result.matches[0].matchedOn, "key")
+  }
+
+  func test_findTranslation_defaultLimitOverloads_returnUpToTen() async throws {
+    // Eleven matching entries — the no-limit overloads must cap at 10. Calling through the
+    // protocol type (`FindingTranslations`) is what routes through the protocol-extension
+    // default-limit overload; calling on the concrete type resolves directly to the
+    // class's `find(query:limit:)` method with `limit = 10` default.
+    let entries = (0..<11).map { i in
+      LocalizationEntry(section: "welcome", key: "hello_\(i)", translations: ["other": "Hello \(i)"])
+    }
+    let sheets = [LocalizationSheet(language: "en_US_English", entries: entries)]
+    let sut: FindingTranslations = FindTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      preferredSheet: nil
+    )
+
+    let single = try await sut.find(query: "hello")
+    XCTAssertEqual(single.matches.count, 10)
+
+    let multi = try await sut.find(queries: ["hello", "world"])
+    XCTAssertEqual(multi.results.count, 2)
+    XCTAssertEqual(multi.results[0].matches.count, 10)
+    XCTAssertEqual(multi.results[1].matches.count, 0)
+  }
 }
 
 /// Loader that records how many times any loading method was called. Used to verify the

--- a/Tests/LinguaTests/Domain/UseCases/Agent/FindAndSectionsTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/FindAndSectionsTests.swift
@@ -48,4 +48,38 @@ final class FindAndSectionsTests: XCTestCase {
     // Either an exact value match (Hello → score 90) or key contains "hello" (80) wins.
     XCTAssertEqual(result.matches.first?.englishValue?.lowercased(), "hello")
   }
+
+  func test_findTranslation_multipleQueries_shareOneLoad_returningPerQueryResults() async throws {
+    let loader = CountingMockLoader(sheets: [
+      LocalizationSheet(language: "en_US_English", entries: [
+        LocalizationEntry(section: "settings", key: "title", translations: ["other": "Settings"]),
+        LocalizationEntry(section: "settings", key: "account", translations: ["other": "Account"]),
+        LocalizationEntry(section: "settings", key: "display_name", translations: ["other": "Display name"])
+      ])
+    ])
+    let sut = FindTranslationUseCase(sheetDataLoader: loader, preferredSheet: nil)
+
+    let result = try await sut.find(queries: ["Settings", "Account", "Display name"], limit: 5)
+
+    XCTAssertEqual(result.results.count, 3)
+    XCTAssertEqual(result.results[0].query, "Settings")
+    XCTAssertEqual(result.results[1].query, "Account")
+    XCTAssertEqual(result.results[2].query, "Display name")
+    // The sheet was loaded exactly once — the whole point of the multi-query path.
+    XCTAssertEqual(loader.loadCount, 1)
+  }
+}
+
+/// Loader that records how many times any loading method was called. Used to verify the
+/// multi-query / canonical-only paths share a single round trip across queries.
+private final class CountingMockLoader: SheetDataLoader {
+  private let sheets: [LocalizationSheet]
+  private(set) var loadCount = 0
+
+  init(sheets: [LocalizationSheet]) { self.sheets = sheets }
+
+  func loadSheets() async throws -> [LocalizationSheet] {
+    loadCount += 1
+    return sheets
+  }
 }

--- a/Tests/LinguaTests/Domain/UseCases/Agent/UpdateTranslationUseCaseTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/UpdateTranslationUseCaseTests.swift
@@ -96,6 +96,7 @@ private final class SpyWriter: GoogleSheetsWriting {
   var inserts: [(String, Int, [String])] = []
   var appends: [(String, [String])] = []
   var cellUpdates: [(tab: String, row: Int, col: Int, value: String)] = []
+  var batchEdits: [SheetBatchEdit] = []
 
   func insertRow(sheetTab: String, oneBasedRowIndex: Int, cells: [String]) async throws {
     inserts.append((sheetTab, oneBasedRowIndex, cells))
@@ -108,4 +109,7 @@ private final class SpyWriter: GoogleSheetsWriting {
     cellUpdates.append((sheetTab, oneBasedRow, oneBasedColumn, value))
   }
   func deleteRow(sheetTab: String, oneBasedRowIndex: Int) async throws {}
+  func applyBatchEdits(_ edits: [SheetBatchEdit]) async throws {
+    batchEdits.append(contentsOf: edits)
+  }
 }

--- a/Tests/LinguaTests/Domain/UseCases/Agent/UpdateTranslationUseCaseTests.swift
+++ b/Tests/LinguaTests/Domain/UseCases/Agent/UpdateTranslationUseCaseTests.swift
@@ -82,6 +82,232 @@ final class UpdateTranslationUseCaseTests: XCTestCase {
     }
   }
 
+  // MARK: - Error paths
+
+  func test_update_throwsNoSheets_whenSheetsEmpty() async {
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success([])),
+      writer: SpyWriter(),
+      preferredSheet: nil
+    )
+    await assertAgentError(code: "no_sheets") {
+      _ = try await sut.update(TranslationUpdate(
+        section: "welcome",
+        key: "title",
+        assignments: [ValueAssignment(language: "en", form: nil, text: "x")]
+      ))
+    }
+  }
+
+  func test_update_throwsInvalidPluralForm_whenFormUnknown() async {
+    let sheets = [sheet(language: "en_US_English", entries: [("welcome", "title", ["one": "Hi"])])]
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyWriter(),
+      preferredSheet: nil
+    )
+    await assertAgentError(code: "invalid_plural_form") {
+      _ = try await sut.update(TranslationUpdate(
+        section: "welcome",
+        key: "title",
+        assignments: [ValueAssignment(language: "en", form: "bogus", text: "x")]
+      ))
+    }
+  }
+
+  func test_update_throwsTabsOutOfSync_whenLanguageTabRowsMisaligned() async {
+    let sheets = [
+      sheet(language: "en_US_English", entries: [
+        ("welcome", "title", ["one": "Hi"]),
+        ("welcome", "subtitle", ["one": "Sub"])
+      ]),
+      sheet(language: "de_DE_German", entries: [
+        ("welcome", "title", ["one": "Hallo"])
+        // missing 'subtitle' → misaligned
+      ])
+    ]
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyWriter(),
+      preferredSheet: "en_US_English"
+    )
+    await assertAgentError(code: "tabs_out_of_sync") {
+      _ = try await sut.update(TranslationUpdate(
+        section: "welcome",
+        key: "title",
+        assignments: [ValueAssignment(language: "de", form: nil, text: "x")]
+      ))
+    }
+  }
+
+  func test_update_defaultFormFallsBackToSheetDetection_whenRowHasNoFilledTranslations() async throws {
+    // Target row has only empty translations → fallback path: detectDefaultForm picks the
+    // dominant form across the sheet. With three other rows using `other`, the fallback is `other`.
+    let sheets = [
+      sheet(language: "en_US_English", entries: [
+        ("welcome", "title", ["other": "Hi"]),
+        ("welcome", "subtitle", ["other": "Sub"]),
+        ("welcome", "footer", ["other": "Foot"]),
+        ("welcome", "blank", ["one": "", "other": ""])
+      ])
+    ]
+    let writer = SpyWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: nil
+    )
+
+    let result = try await sut.update(TranslationUpdate(
+      section: "welcome",
+      key: "blank",
+      assignments: [ValueAssignment(language: "en", form: nil, text: "Filled")]
+    ))
+
+    XCTAssertEqual(result.resolvedDefaultForm, "other")
+    XCTAssertEqual(writer.cellUpdates.first?.col, 8) // column H = `other`
+  }
+
+  // MARK: - updateBatch
+
+  func test_updateBatch_writesEditsViaApplyBatchEdits() async throws {
+    let sheets = [
+      sheet(language: "en_US_English", entries: [
+        ("welcome", "title", ["one": "Hi"]),
+        ("welcome", "subtitle", ["one": "Sub"])
+      ]),
+      sheet(language: "de_DE_German", entries: [
+        ("welcome", "title", ["one": "Hallo"]),
+        ("welcome", "subtitle", ["one": "Untertitel"])
+      ])
+    ]
+    let writer = SpyWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: "en_US_English"
+    )
+
+    let result = try await sut.updateBatch([
+      TranslationUpdate(
+        section: "welcome",
+        key: "title",
+        assignments: [ValueAssignment(language: "de", form: nil, text: "Hi-DE")]
+      )
+    ])
+
+    XCTAssertEqual(result.totalUpdated, 1)
+    XCTAssertEqual(result.items.count, 1)
+    XCTAssertTrue(result.notFound.isEmpty)
+    XCTAssertEqual(writer.batchEdits.count, 1)
+    XCTAssertEqual(writer.batchEdits[0].sheetTab, "de_DE_German")
+    XCTAssertEqual(writer.batchEdits[0].startRow, 2)
+    XCTAssertEqual(writer.batchEdits[0].startColumn, 4) // `one` column
+  }
+
+  func test_updateBatch_recordsNotFound_whenKeyMissing() async throws {
+    let sheets = [sheet(language: "en_US_English", entries: [("welcome", "title", ["one": "Hi"])])]
+    let writer = SpyWriter()
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: writer,
+      preferredSheet: nil
+    )
+
+    let result = try await sut.updateBatch([
+      TranslationUpdate(
+        section: "welcome",
+        key: "missing",
+        assignments: [ValueAssignment(language: "en", form: nil, text: "x")]
+      )
+    ])
+
+    XCTAssertEqual(result.totalUpdated, 0)
+    XCTAssertEqual(result.notFound.count, 1)
+    XCTAssertEqual(result.notFound[0].key, "missing")
+    XCTAssertTrue(writer.batchEdits.isEmpty)
+  }
+
+  func test_updateBatch_throwsNoSheets_whenSheetsEmpty() async {
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success([])),
+      writer: SpyWriter(),
+      preferredSheet: nil
+    )
+    await assertAgentError(code: "no_sheets") {
+      _ = try await sut.updateBatch([
+        TranslationUpdate(
+          section: "welcome",
+          key: "title",
+          assignments: [ValueAssignment(language: "en", form: nil, text: "x")]
+        )
+      ])
+    }
+  }
+
+  func test_updateBatch_throwsInvalidPluralForm_whenFormUnknown() async {
+    let sheets = [sheet(language: "en_US_English", entries: [("welcome", "title", ["one": "Hi"])])]
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyWriter(),
+      preferredSheet: nil
+    )
+    await assertAgentError(code: "invalid_plural_form") {
+      _ = try await sut.updateBatch([
+        TranslationUpdate(
+          section: "welcome",
+          key: "title",
+          assignments: [ValueAssignment(language: "en", form: "bogus", text: "x")]
+        )
+      ])
+    }
+  }
+
+  func test_updateBatch_throwsTabsOutOfSync_whenLanguageTabRowsMisaligned() async {
+    let sheets = [
+      sheet(language: "en_US_English", entries: [
+        ("welcome", "title", ["one": "Hi"]),
+        ("welcome", "subtitle", ["one": "Sub"])
+      ]),
+      sheet(language: "de_DE_German", entries: [
+        ("welcome", "title", ["one": "Hallo"])
+        // missing 'subtitle' → misaligned
+      ])
+    ]
+    let sut = UpdateTranslationUseCase(
+      sheetDataLoader: MockSheetDataLoader(loadSheetsResult: .success(sheets)),
+      writer: SpyWriter(),
+      preferredSheet: "en_US_English"
+    )
+    await assertAgentError(code: "tabs_out_of_sync") {
+      _ = try await sut.updateBatch([
+        TranslationUpdate(
+          section: "welcome",
+          key: "title",
+          assignments: [ValueAssignment(language: "de", form: nil, text: "x")]
+        )
+      ])
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func assertAgentError(
+    code expectedCode: String,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ block: () async throws -> Void
+  ) async {
+    do {
+      try await block()
+      XCTFail("Expected AgentError(\(expectedCode))", file: file, line: line)
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, expectedCode, file: file, line: line)
+    } catch {
+      XCTFail("Wrong error type: \(error)", file: file, line: line)
+    }
+  }
+
   private func sheet(language: String, entries: [(String, String, [String: String])]) -> LocalizationSheet {
     LocalizationSheet(
       language: language,

--- a/Tests/LinguaTests/Infrastructure/Data/GoogleSheets/Fetcher/GoogleSheetDataLoaderTests.swift
+++ b/Tests/LinguaTests/Infrastructure/Data/GoogleSheets/Fetcher/GoogleSheetDataLoaderTests.swift
@@ -29,15 +29,94 @@ final class GoogleSheetDataLoaderTests: XCTestCase {
     let sheetDataResponse = SheetDataResponse(values: [])
     let fetcher = MockGoogleSheetsFetcher(sheetMetadata: sheetMetadata, sheetData: sheetDataResponse)
     let sut = makeSUT(fetcher: fetcher)
-    
+
     let result = try await sut.loadSheets()
-    
+
     XCTAssertEqual(result.count, 0)
+  }
+
+  // MARK: - loadCanonicalSheet
+
+  func test_loadCanonicalSheet_preferred_isUsedWhenPresent_andOnlyFetchesThatTab() async throws {
+    let fetcher = TrackingGoogleSheetsFetcher(
+      tabNames: ["en_US_English", "de_DE_German", "fr_FR_French"]
+    )
+    let sut = makeSUT(fetcher: fetcher)
+
+    let load = try await sut.loadCanonicalSheet(preferred: "de_DE_German")
+
+    XCTAssertEqual(load.canonical.language, "de_DE_German")
+    XCTAssertEqual(load.allLanguageTabNames, ["en_US_English", "de_DE_German", "fr_FR_French"])
+    XCTAssertEqual(fetcher.dataRequests, ["de_DE_German"])
+  }
+
+  func test_loadCanonicalSheet_fallsBackToEnglish_whenPreferredNil() async throws {
+    let fetcher = TrackingGoogleSheetsFetcher(
+      tabNames: ["de_DE_German", "en_US_English", "fr_FR_French"]
+    )
+    let sut = makeSUT(fetcher: fetcher)
+
+    let load = try await sut.loadCanonicalSheet(preferred: nil)
+
+    XCTAssertEqual(load.canonical.language, "en_US_English")
+    XCTAssertEqual(fetcher.dataRequests, ["en_US_English"])
+  }
+
+  func test_loadCanonicalSheet_fallsBackToFirstTab_whenNoEnglish() async throws {
+    let fetcher = TrackingGoogleSheetsFetcher(
+      tabNames: ["de_DE_German", "fr_FR_French"]
+    )
+    let sut = makeSUT(fetcher: fetcher)
+
+    let load = try await sut.loadCanonicalSheet(preferred: nil)
+
+    XCTAssertEqual(load.canonical.language, "de_DE_German")
+    XCTAssertEqual(fetcher.dataRequests, ["de_DE_German"])
+  }
+
+  func test_loadCanonicalSheet_throwsNoSheets_whenNoTabs() async {
+    let fetcher = TrackingGoogleSheetsFetcher(tabNames: [])
+    let sut = makeSUT(fetcher: fetcher)
+
+    do {
+      _ = try await sut.loadCanonicalSheet(preferred: nil)
+      XCTFail("Expected no_sheets")
+    } catch let error as AgentError {
+      XCTAssertEqual(error.code, "no_sheets")
+    } catch {
+      XCTFail("Wrong error: \(error)")
+    }
+    XCTAssertTrue(fetcher.dataRequests.isEmpty)
   }
 }
 
 private extension GoogleSheetDataLoaderTests {
   func makeSUT(fetcher: GoogleSheetsFetchable, sheetDataDecoder: SheetDataDecoder = LocalizationSheetDataDecoder()) -> SheetDataLoader {
     GoogleSheetDataLoader(fetcher: fetcher, sheetDataDecoder: sheetDataDecoder)
+  }
+}
+
+/// Mock that exposes per-tab data and records which tabs were fetched, so we can verify
+/// `loadCanonicalSheet` only hits the canonical tab.
+private final class TrackingGoogleSheetsFetcher: GoogleSheetsFetchable {
+  let tabNames: [String]
+  private(set) var dataRequests: [String] = []
+
+  init(tabNames: [String]) {
+    self.tabNames = tabNames
+  }
+
+  func fetchSheetNames() async throws -> SheetMetadata {
+    SheetMetadata(sheets: tabNames.map {
+      SheetMetadata.Sheet(properties: SheetMetadata.Sheet.SheetProperties(title: $0))
+    })
+  }
+
+  func fetchSheetData(sheetName: String) async throws -> SheetDataResponse {
+    dataRequests.append(sheetName)
+    return SheetDataResponse(values: [
+      ["Section", "Key", "Unused", "Translation"],
+      ["welcome", "title", "", "Hello"]
+    ])
   }
 }

--- a/Tests/LinguaTests/Infrastructure/Data/GoogleSheets/Writer/GoogleSheetsWriterTests.swift
+++ b/Tests/LinguaTests/Infrastructure/Data/GoogleSheets/Writer/GoogleSheetsWriterTests.swift
@@ -233,6 +233,97 @@ final class GoogleSheetsWriterTests: XCTestCase {
     XCTAssertEqual(metadataCalls.count, 1)
   }
 
+  // MARK: - applyBatchEdits
+
+  func test_applyBatchEdits_emitsSingleBatchUpdate_withWriteOnlyBeforeInsertsDescending() async throws {
+    let recorder = RequestRecorder()
+    HandlerURLProtocol.setHandler { request in
+      recorder.record(request)
+      let url = request.url!.absoluteString
+      if url.contains("?fields=sheets.properties") {
+        let payload = """
+        {"sheets":[{"properties":{"sheetId":100,"title":"en"}},{"properties":{"sheetId":200,"title":"de"}}]}
+        """
+        return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(payload.utf8))
+      }
+      return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
+    }
+
+    let sut = makeSUT()
+    try await sut.applyBatchEdits([
+      SheetBatchEdit(sheetTab: "en", startRow: 30, rows: [["x", "y"]], mode: .insertRows),
+      SheetBatchEdit(sheetTab: "en", startRow: 60, rows: [["a", "b"]], mode: .writeOnly),
+      SheetBatchEdit(sheetTab: "en", startRow: 80, rows: [["p", "q"]], mode: .insertRows),
+      SheetBatchEdit(sheetTab: "de", startRow: 30, rows: [["xd", "yd"]], mode: .insertRows)
+    ])
+
+    // First request(s) are the metadata fetch; everything else is a single batchUpdate.
+    let batchRequests = recorder.requests.filter { ($0.httpMethod ?? "GET") == "POST" }
+    XCTAssertEqual(batchRequests.count, 1, "all edits should fit in one HTTP round trip")
+
+    let body = try XCTUnwrap(recorder.bodies.last)
+    let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    let requests = try XCTUnwrap(json["requests"] as? [[String: Any]])
+
+    // Expected ordering of inner requests:
+    //   - writeOnly (60) → updateCells
+    //   - insert (80)    → insertDimension + updateCells
+    //   - insert (30 en) → insertDimension + updateCells     (between the two row-30 inserts,
+    //   - insert (30 de) → insertDimension + updateCells       order within the same row is stable)
+    // Total = 1 + 2 + 2 + 2 = 7 inner requests.
+    XCTAssertEqual(requests.count, 7)
+
+    XCTAssertNotNil(requests[0]["updateCells"], "writeOnly comes first")
+    XCTAssertNotNil(requests[1]["insertDimension"], "highest row insert runs before lower rows")
+    XCTAssertNotNil(requests[2]["updateCells"])
+    XCTAssertNotNil(requests[3]["insertDimension"], "row-30 inserts come last")
+    XCTAssertNotNil(requests[4]["updateCells"])
+
+    // Column index for an insert is 0 (we always insert from column A).
+    let firstWriteStart = try XCTUnwrap((requests[0]["updateCells"] as? [String: Any])?["start"] as? [String: Any])
+    XCTAssertEqual(firstWriteStart["rowIndex"] as? Int, 59) // 0-indexed
+    XCTAssertEqual(firstWriteStart["columnIndex"] as? Int, 0)
+  }
+
+  func test_applyBatchEdits_emptyEdits_doesNothing() async throws {
+    let recorder = RequestRecorder()
+    HandlerURLProtocol.setHandler { request in
+      recorder.record(request)
+      return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
+    }
+    let sut = makeSUT()
+    try await sut.applyBatchEdits([])
+    XCTAssertTrue(recorder.requests.isEmpty)
+  }
+
+  func test_applyBatchEdits_writeOnlyAtColumnD_targetsCorrectCell() async throws {
+    let recorder = RequestRecorder()
+    HandlerURLProtocol.setHandler { request in
+      recorder.record(request)
+      let url = request.url!.absoluteString
+      if url.contains("?fields=sheets.properties") {
+        let payload = """
+        {"sheets":[{"properties":{"sheetId":5,"title":"Tab"}}]}
+        """
+        return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(payload.utf8))
+      }
+      return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
+    }
+
+    let sut = makeSUT()
+    try await sut.applyBatchEdits([
+      SheetBatchEdit(sheetTab: "Tab", startRow: 7, startColumn: 4, rows: [["new value"]], mode: .writeOnly)
+    ])
+
+    let body = try XCTUnwrap(recorder.bodies.last)
+    let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    let requests = try XCTUnwrap(json["requests"] as? [[String: Any]])
+    let updateCells = try XCTUnwrap(requests.first?["updateCells"] as? [String: Any])
+    let start = try XCTUnwrap(updateCells["start"] as? [String: Any])
+    XCTAssertEqual(start["rowIndex"] as? Int, 6)     // 0-indexed
+    XCTAssertEqual(start["columnIndex"] as? Int, 3)  // column D, 0-indexed
+  }
+
   // MARK: - deleteRow
 
   func test_deleteRow_sendsDeleteDimensionRequest() async throws {


### PR DESCRIPTION
## Summary

  Cuts the end-to-end agent loop for adding localized strings from ~75 seconds to
  ~7 seconds (~10× faster) on a typical "localize this view" task. The win comes
  from collapsing repeated full-sheet fetches and N sequential writes into one
  HTTP round trip, plus folding `sync` into the write command.

  ## Changes

  **Library**

  - **`lingua add --batch <file.json>` / `lingua update --batch <file.json>`** — bulk
    add/update from a JSON array of `{section, key, values}`. One Google Sheets
    `batchUpdate` HTTP call regardless of how many keys are in the file. Handles
    existing-section inserts (sorted descending by row) and new-section appends
    (writeOnly) in the same payload.
  - **`--sync ios|android|ios,android`** flag on `add` and `update` — regenerates
    platform files inline, saving a separate `lingua sync` invocation.
  - **Canonical-only sheet loading** — `lingua find` and `lingua sections` now do
    1 metadata + 1 data fetch instead of N data fetches. New
    `SheetDataLoader.loadCanonicalSheet(preferred:)` with default impl so test
    mocks keep working unchanged.
  - **Multi-query `lingua find`** — `lingua find <config> "a" "b" "c"` shares one
    sheet load across all queries; response shape becomes `{canonicalSheet, results}`.
  - **Per-subcommand `--help`** — `lingua add --help`, `lingua add ./config.json
    --help`, `lingua ai --help`, etc. all print useful help instead of failing on
    config-path or argument validation.
  - **Boolean-flag whitelist in parser** — fixes a class of bugs where `--flag value`
    (e.g. `--new-section Settings`) was silently consumed as a valued flag, leaving
    the boolean unset.

  **Bundled Agent Skills** (`lingua ai install` to refresh)

  - `lingua-add-translation` and `lingua-update-translation` rewritten to teach
    `--batch` + `--sync`, with a JSON schema example for plain and plural values.
  - Plural-key codegen documented (`Lingua.<Section>.<camelKey>(_:)`) so the agent
    stops reading the generator source to figure out the symbol shape.
  - `lingua-find-key` documents the multi-query form.

  ## Backwards compatibility

  - The single-key `lingua add --section ... --key ... --value ...` form continues
    to work unchanged.
  - `lingua find <config> <query>` still returns the original
    `{canonicalSheet, query, matches}` envelope; the new multi-query shape is only
    emitted when multiple queries are passed.
  - No config file changes required.
  - Existing skill files on disk are skipped unless `lingua ai install --force`
    is passed, matching prior behavior.

  ## Test plan

  - [x] `swift test` — full suite passes (292 tests, 23 new).
  - [x] Refresh installed skills (`lingua ai install --force` or `--global --force`)
        and run an agentic add against a real sheet to verify the end-to-end loop.
  - [x] Spot-check an existing-section insert with multiple keys (batched
        `insertDimension` ordering).
  - [x] Spot-check `update --batch` with a mix of found and missing keys
        (verify `notFound` collection).